### PR TITLE
pref: Remove deprecated configuration `bypass_guild_check`

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -14,10 +14,5 @@ logger_format='compact'
 
 [preview]
 
-# Sets whether the guild check process is bypassed when quoting.
-# If the guild check process is bypassed, messages can be shared and quoted from all guilds in which babyrite is installed.
-# However, the message will be shared to members who do not belong to that guild. This setting is recommended when babyrite is used by multiple private guilds.
-bypass_guild_check=false
-
 # Whether to enable mentions in quoted messages.
 is_mention=true

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -14,7 +14,6 @@ Recommended settings are as follows:
 logger_format='compact'
 
 [preview]
-bypass_guild_check=false
 is_mention=true
 ```
 
@@ -55,17 +54,6 @@ Sets the format of the log output. Both will show logs above babyrite's `INFO` l
 > }
 > ```
 
-#### `preview.bypass_guild_check`
-
-> *Available in [v0.9.0](https://github.com/m1sk9/babyrite/releases/tag/babyrite-v0.9.0)*
->
-> *Expected type: boolean*
-
-Sets whether the guild check process is bypassed when quoting.
-If the guild check process is bypassed, messages can be shared and quoted from all guilds in which babyrite is installed.
-
-However, the message will be shared to members who do not belong to that guild. This setting is recommended when babyrite is used by multiple private guilds.
-
 > [!CAUTION]
 >
 > Note that if you enable `bypass_guilds`, bots may be used for malicious purposes. This setting is only intended for use when babyrite is used among a limited group.
@@ -78,4 +66,19 @@ However, the message will be shared to members who do not belong to that guild. 
 >
 > *Expected type: boolean*
 
-Whether or not to make a quoted message mentions.
+Whether to make a quoted message mentions.
+
+------
+
+### Deprecated Configuration
+
+#### `preview.bypass_guild_check`
+
+> *Unavailable in [v0.12.2](https://github.com/m1sk9/babyrite/releases/tag/babyrite-v0.12.2)*  
+>    --- Reason: This setting is not recommended for use in a public environment.
+
+
+Sets whether the guild check process is bypassed when quoting.
+If the guild check process is bypassed, messages can be shared and quoted from all guilds in which babyrite is installed.
+
+However, the message will be shared to members who do not belong to that guild. This setting is recommended when babyrite is used by multiple private guilds.

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,6 @@ pub enum LoggerFormat {
 
 #[derive(Debug, Deserialize)]
 pub struct PreviewConfig {
-    pub bypass_guild_check: bool,
     pub is_mention: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,12 +53,6 @@ async fn main() -> anyhow::Result<()> {
     }
 
     tracing::info!("Configuration: {:?}", config);
-    if config.preview.bypass_guild_check {
-        tracing::warn!(
-            "The guild bypass setting is enabled. Quote messages between different guilds. "
-        )
-    }
-
     let intents = GatewayIntents::MESSAGE_CONTENT | GatewayIntents::GUILD_MESSAGES;
     let mut client = serenity::Client::builder(&envs.discord_api_token, intents)
         .event_handler(handler::BabyriteHandler)

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -103,9 +103,7 @@ impl MessagePreviewIDs {
         ctx: &Context,
         is_private: bool,
     ) -> anyhow::Result<MessagePreview, MessagePreviewError> {
-        let config = crate::config::BabyriteConfig::get();
         let guild = self.guild_id;
-
         let channel =
             if let Some(channel) = MESSAGE_PREVIEW_CHANNEL_CACHE.get(&self.channel_id).await {
                 channel
@@ -131,9 +129,9 @@ impl MessagePreviewIDs {
             };
         debug!("channel: {:?}", channel);
 
-        if !config.preview.bypass_guild_check && guild != channel.guild_id {
+        if guild != channel.guild_id {
             return Err(MessagePreviewError::GuildError(
-                "mismatched guilds (set `bypass_guilds` to `true` to enable citation)".to_string(),
+                "Mismatched guilds".to_string(),
             ));
         }
 


### PR DESCRIPTION
Remove configuration `preview.bypass_guild_check`. This settings is not recommend for use in a public.