### PR TITLE
feat: Support for ARM64 environment

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -31,6 +31,7 @@ runs:
 
     - name: Build and push
       uses: docker/build-push-action@v6
+      platforms: linux/amd64,linux/arm64
       with:
         push: true
         tags: |

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -31,9 +31,9 @@ runs:
 
     - name: Build and push
       uses: docker/build-push-action@v6
-      platforms: linux/amd64,linux/arm64
       with:
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: |
           ghcr.io/m1sk9/babyrite:latest
           ghcr.io/m1sk9/babyrite:${{ inputs.sha }}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker pull ghcr.io/m1sk9/babyrite:v0
 
 - babyrite is tested on macOS and Linux (major distributions) as recommended environment.
   - Windows is deprecated as it has not been tested.
-- ARM64 environment is supported. (v0.16.0 or later)
+- ARM64 environments are supported (v0.16.0+)
 
 ### Using Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ docker pull ghcr.io/m1sk9/babyrite:latest
 docker pull ghcr.io/m1sk9/babyrite:v0
 
 # Specific Release
-docker pull ghcr.io/m1sk9/babyrite:v0.15.0
+docker pull ghcr.io/m1sk9/babyrite:v0.16.0
 ```
 
 [_API Support: requires Discord API v10_](https://discord.com/developers/docs/reference#api-versioning)
@@ -30,12 +30,24 @@ docker pull ghcr.io/m1sk9/babyrite:v0.15.0
 
 ## Installation
 
+You can install babyrite using Docker. The following command will pull the latest version of babyrite.
+
+```shell
+docker pull ghcr.io/m1sk9/babyrite:v0
+```
+
+- babyrite is tested on macOS and Linux (major distributions) as recommended environment.
+  - Windows is deprecated as it has not been tested.
+- ARM64 environment is supported. (v0.16.0 or later)
+
+### Using Docker Compose
+
 It is recommended to use Docker Compose when setting up babyrite. Direct startup using Docker images or binary files is also possible but not recommended.
 
 ```yaml
 services:
   app:
-    image: ghcr.io/m1sk9/babyrite:v0.15.0
+    image: ghcr.io/m1sk9/babyrite:v0
     env_file:
       - .env
     restart: always


### PR DESCRIPTION
ARM64 environment is now supported.
It is now possible to pull images directly from macOS and Linux running on ARM64 environments, including Apple Silicon (M*).

Note that this change applies only to v0.16.0 or later images to be released in the future.