### PR TITLE
feat: Use default value for environment variable `CONFIG_FILE_PATH` even if it is an empty string

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Discord API token
 DISCORD_API_TOKEN=
 # Configuration file path (relative path)
+## If you do not specify a key or value, the default value will be used.
 CONFIG_FILE_PATH=

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,11 @@ use serenity::all::GatewayIntents;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use utils::config::PreviewConfig;
 
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Debug)]
 pub struct EnvConfig {
     pub discord_api_token: String,
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::utils::config::empty_string_as_none")]
     pub config_file_path: Option<String>,
 }
 
@@ -25,6 +27,8 @@ async fn main() -> anyhow::Result<()> {
 
     PreviewConfig::init()?;
     let envs = get_env_config();
+    tracing::debug!("Config: {:?}", PreviewConfig::get_config());
+
     match PreviewConfig::get_feature_flag("json_logging") {
         true => {
             tracing_subscriber::registry()

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -1,3 +1,5 @@
+use serde::Deserialize;
+
 pub static CONFIG: once_cell::sync::OnceCell<PreviewConfig> = once_cell::sync::OnceCell::new();
 
 #[derive(serde::Deserialize, Debug)]
@@ -58,4 +60,13 @@ impl PreviewConfig {
         let c = Self::get_config();
         c.feature_flag.as_ref().is_some_and(|f| f.contains(flag))
     }
+}
+
+/// Deserialize a string as an `Option<String>`, treating empty strings as `None`.
+pub fn empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt = Option::<String>::deserialize(deserializer)?;
+    Ok(opt.filter(|s| !s.is_empty()))
 }


### PR DESCRIPTION
The environment variable `CONFIG_FILE_PATH` is now interpreted by rustc as `Some(“”)`, since specifying only a key would result in an empty string, and babyrite would not start without the default value.

From now on `CONFIG_FILE_PATH` will use the default value even if only the key is specified.

This pull request introduces enhancements to configuration handling and debugging in the codebase. The changes include improved deserialization logic for optional configuration fields, added debugging information.