### PR TITLE
feat: Deprecate `json_logging`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ You can customize the behavior of babyrite by using a dedicated configuration fi
 You can also start with the default settings without configuring. The following are the default settings used in that case.
 
 ```toml
-feature_flag = ""
 is_mention = true
 is_deletable = true
 is_allow_nsfw = false
@@ -70,7 +69,6 @@ is_allow_nsfw = false
 
 | Key             | Description                                                                    | Default Value |
 | --------------- | ------------------------------------------------------------------------------ | ------------- |
-| `feature_flag`  | Flags to change the behavior of Babyrite. Specify them separated by commas.    | `""` (empty)  |
 | `is_mention`    | Specifies whether to mention the request sender when generating a preview.     | `true`        |
 | `is_deletable`  | Sets whether to enable the deletion of previews.                               | `true`        |
 | `is_allow_nsfw` | Sets whether to allow the generation of messages from channels marked as NSFW. | `false`       |

--- a/config/config.toml
+++ b/config/config.toml
@@ -4,12 +4,6 @@
 # The settings are written in TOML format. To use the configuration file, specify the recursive path to the configuration file in the environment variable "CONFIG_FILE_PATH" injected into the container.
 # Note that babyrite will run with default settings if not configured.
 
-# Startup settings (Feature Flags)
-## Flags to change the behavior of babyrite. Specify them separated by commas. The default is empty.
-## The valid flags are as follows:
-## - "json_logging": Outputs logs in JSON format (useful when integrating with log collection tools like Grafana Loki)
-feature_flag = ""
-
 # Mention settings for preview generation (default is enabled)
 ## Mentions the request sender when generating a preview.
 is_mention = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,27 +29,13 @@ async fn main() -> anyhow::Result<()> {
     let envs = get_env_config();
     tracing::debug!("Config: {:?}", PreviewConfig::get_config());
 
-    match PreviewConfig::get_feature_flag("json_logging") {
-        true => {
-            tracing_subscriber::registry()
-                .with(
-                    tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| "babyrite=debug,serenity=debug".into()),
-                )
-                .with(tracing_subscriber::fmt::layer().json())
-                .init();
-            tracing::info!("Feature Flag : Log output in JSON format is now enabled.");
-        }
-        false => {
-            tracing_subscriber::registry()
-                .with(
-                    tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| "babyrite=debug,serenity=debug".into()),
-                )
-                .with(tracing_subscriber::fmt::layer().compact())
-                .init();
-        }
-    }
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "babyrite=debug,serenity=debug".into()),
+        )
+        .with(tracing_subscriber::fmt::layer().compact())
+        .init();
 
     let mut client = serenity::Client::builder(
         &envs.discord_api_token,

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -4,8 +4,6 @@ pub static CONFIG: once_cell::sync::OnceCell<PreviewConfig> = once_cell::sync::O
 
 #[derive(serde::Deserialize, Debug)]
 pub struct PreviewConfig {
-    // Enable optional features.
-    pub feature_flag: Option<String>,
     // If enabled, previews are generated with mentions.
     pub is_mention: bool,
     // If enabled, preview can be deleted.
@@ -17,7 +15,6 @@ pub struct PreviewConfig {
 impl Default for PreviewConfig {
     fn default() -> Self {
         Self {
-            feature_flag: None,
             is_mention: true,
             is_deletable: true,
             is_allow_nsfw: false,
@@ -54,11 +51,6 @@ impl PreviewConfig {
 
     pub fn get_config() -> &'static PreviewConfig {
         CONFIG.get().expect("Failed to get configuration.")
-    }
-
-    pub fn get_feature_flag(flag: &str) -> bool {
-        let c = Self::get_config();
-        c.feature_flag.as_ref().is_some_and(|f| f.contains(flag))
     }
 }
 


### PR DESCRIPTION
The `json_logging` feature, which was useful in some situations such as Grafana Loki, is deprecated.

JSON format output will no longer be available after the v0.17.0 release.