### PR TITLE
feat: Added channel list cache functionality

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "babyrite=debug,serenity=debug".into()),
+                .unwrap_or_else(|_| "babyrite=debug,serenity=info".into()),
         )
         .with(tracing_subscriber::fmt::layer().compact())
         .init();

--- a/src/message.rs
+++ b/src/message.rs
@@ -61,7 +61,7 @@ impl MessageLinkIDs {
             channel_id: self.channel_id,
         };
 
-        let channel = args.get_channel_from_cache(&ctx).await?;
+        let channel = args.get_channel_from_cache(ctx).await?;
         let message = channel.message(&ctx.http, self.message_id).await?;
 
         Ok(MessagePreview {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,4 @@
-use crate::utils::cache::get_channel_from_cache;
+use crate::utils::cache::CacheArgs;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serenity::all::{ChannelId, GuildChannel, GuildId, Message, MessageId};
@@ -56,8 +56,12 @@ impl MessageLinkIDs {
         &self,
         ctx: &serenity::prelude::Context,
     ) -> anyhow::Result<MessagePreview> {
-        let guild = self.guild_id;
-        let channel = get_channel_from_cache(self.channel_id, guild, ctx).await?;
+        let args = CacheArgs {
+            guild_id: self.guild_id,
+            channel_id: self.channel_id,
+        };
+
+        let channel = args.get_channel_from_cache(&ctx).await?;
         let message = channel.message(&ctx.http, self.message_id).await?;
 
         Ok(MessagePreview {

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -1,6 +1,9 @@
 use anyhow::Context as _;
-use serenity::all::{ChannelId, GuildChannel, GuildId};
+use moka::future::{Cache, CacheBuilder};
+use once_cell::sync::Lazy;
+use serenity::all::{ChannelId, Guild, GuildChannel, GuildId};
 use serenity::client::Context;
+use std::collections::HashMap;
 
 pub static MESSAGE_PREVIEW_CHANNEL_CACHE: once_cell::sync::Lazy<
     moka::future::Cache<ChannelId, GuildChannel>,
@@ -9,6 +12,27 @@ pub static MESSAGE_PREVIEW_CHANNEL_CACHE: once_cell::sync::Lazy<
         moka::future::CacheBuilder::new(1000)
             .name("message_preview_channel_cache")
             .time_to_idle(std::time::Duration::from_secs(3600))
+            .build()
+    })
+};
+
+// Cache for guilds to reduce API calls
+pub static GUILD_CACHE: Lazy<Cache<GuildId, Guild>> = {
+    Lazy::new(|| {
+        CacheBuilder::new(500)
+            .name("guild_cache")
+            .time_to_idle(std::time::Duration::from_secs(3600))
+            .time_to_live(std::time::Duration::from_secs(43200))
+            .build()
+    })
+};
+
+pub static GUILD_CHANNELS_CACHE: Lazy<Cache<GuildId, HashMap<ChannelId, GuildChannel>>> = {
+    Lazy::new(|| {
+        CacheBuilder::new(500)
+            .name("guild_channels_cache")
+            .time_to_idle(std::time::Duration::from_secs(3600))
+            .time_to_live(std::time::Duration::from_secs(43200))
             .build()
     })
 };

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -1,76 +1,106 @@
 use anyhow::Context as _;
 use moka::future::{Cache, CacheBuilder};
 use once_cell::sync::Lazy;
-use serenity::all::{ChannelId, Guild, GuildChannel, GuildId};
+use serenity::all::{ChannelId, GuildChannel, GuildId};
 use serenity::client::Context;
 use std::collections::HashMap;
+use thiserror::Error;
 
-pub static MESSAGE_PREVIEW_CHANNEL_CACHE: once_cell::sync::Lazy<
-    moka::future::Cache<ChannelId, GuildChannel>,
-> = {
-    once_cell::sync::Lazy::new(|| {
-        moka::future::CacheBuilder::new(1000)
-            .name("message_preview_channel_cache")
-            .time_to_idle(std::time::Duration::from_secs(3600))
-            .build()
-    })
-};
+pub struct CacheArgs {
+    pub guild_id: GuildId,
+    pub channel_id: ChannelId,
+}
 
-// Cache for guilds to reduce API calls
-pub static GUILD_CACHE: Lazy<Cache<GuildId, Guild>> = {
+#[derive(Error, Debug)]
+enum CacheError {
+    #[error("Entity not found in cache")]
+    CacheNotFound,
+}
+
+// Cache for guild channels (channel list)
+pub static GUILD_CHANNEL_LIST_CACHE: Lazy<Cache<GuildId, HashMap<ChannelId, GuildChannel>>> = {
     Lazy::new(|| {
         CacheBuilder::new(500)
-            .name("guild_cache")
+            .name("guild_channel_list_cache")
             .time_to_idle(std::time::Duration::from_secs(3600))
             .time_to_live(std::time::Duration::from_secs(43200))
             .build()
     })
 };
 
-pub static GUILD_CHANNELS_CACHE: Lazy<Cache<GuildId, HashMap<ChannelId, GuildChannel>>> = {
+// Cache for guild channel
+pub static GUILD_CHANNEL_CACHE: Lazy<Cache<ChannelId, GuildChannel>> = {
     Lazy::new(|| {
         CacheBuilder::new(500)
-            .name("guild_channels_cache")
+            .name("guild_channel_cache")
             .time_to_idle(std::time::Duration::from_secs(3600))
             .time_to_live(std::time::Duration::from_secs(43200))
             .build()
     })
 };
 
-pub async fn get_channel_from_cache(
-    id: ChannelId,
-    guild: GuildId,
-    ctx: &Context,
-) -> anyhow::Result<GuildChannel> {
-    let channel = match MESSAGE_PREVIEW_CHANNEL_CACHE.get(&id).await {
-        Some(c) => Ok(c),
-        _ => {
-            let channels = guild
-                .channels(&ctx.http)
-                .await
-                .context("Failed to get channels.")?;
-            if let Some(channel) = channels.get(&id) {
-                Ok(channel.clone())
-            } else {
-                let guild_threads = guild
-                    .get_active_threads(&ctx.http)
-                    .await
-                    .context("Failed to get active threads.")?;
-                guild_threads
-                    .threads
-                    .iter()
-                    .find(|c| c.id == id)
-                    .cloned()
-                    .context("Failed to find channel.")
+impl CacheArgs {
+    pub async fn get_channel_from_cache(&self, ctx: &Context) -> anyhow::Result<GuildChannel> {
+        // 1. Try to get from channel cache
+        match GUILD_CHANNEL_CACHE.get(&self.channel_id).await {
+            // 2-a. If found, return it
+            Some(channel) => Ok(channel),
+            // 2-b. If not found, try to get from channel list cache.
+            None => {
+                // 3. Try to get from channel list cache
+                if let Some(channels) = GUILD_CHANNEL_LIST_CACHE.get(&self.guild_id).await {
+                    // 4. If found, try to get the channel from the list
+                    channels
+                        .get(&self.channel_id)
+                        .cloned()
+                        .ok_or_else(|| anyhow::anyhow!("Channel not found in cache"))?;
+                }
+
+                // 5. If not found, fetch from API and update the cache
+                let channel_list = self.get_channel_list_from_api(ctx).await?;
+                let channel = match channel_list.get(&self.channel_id).cloned() {
+                    Some(c) => c,
+                    None => {
+                        let data = self
+                            .guild_id
+                            .get_active_threads(&ctx.http)
+                            .await
+                            .context("Failed to get active threads")?;
+                        data.threads
+                            .iter()
+                            .find(|t| t.id == self.channel_id)
+                            .cloned()
+                            .ok_or(CacheError::CacheNotFound)?
+                    }
+                };
+
+                // 6. Update the channel cache
+                GUILD_CHANNEL_CACHE
+                    .insert(self.channel_id, channel.clone())
+                    .await;
+                Ok(channel)
             }
         }
-    };
+    }
 
-    match channel {
-        Ok(c) => {
-            MESSAGE_PREVIEW_CHANNEL_CACHE.insert(id, c.clone()).await;
-            Ok(c)
-        }
-        _ => channel,
+    async fn get_channel_list_from_api(
+        &self,
+        ctx: &Context,
+    ) -> anyhow::Result<HashMap<ChannelId, GuildChannel>> {
+        let guild = ctx
+            .http
+            .get_guild(self.guild_id)
+            .await
+            .context("Failed to get guild")?;
+        let channels = guild
+            .channels(&ctx)
+            .await
+            .context("Failed to get channel list")?;
+
+        GUILD_CHANNEL_LIST_CACHE
+            .insert(self.guild_id, channels.clone())
+            .await;
+
+        Ok(channels)
     }
 }

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -4,17 +4,10 @@ use once_cell::sync::Lazy;
 use serenity::all::{ChannelId, GuildChannel, GuildId};
 use serenity::client::Context;
 use std::collections::HashMap;
-use thiserror::Error;
 
 pub struct CacheArgs {
     pub guild_id: GuildId,
     pub channel_id: ChannelId,
-}
-
-#[derive(Error, Debug)]
-enum CacheError {
-    #[error("Entity not found in cache")]
-    CacheNotFound,
 }
 
 // Cache for guild channels (channel list)
@@ -50,10 +43,10 @@ impl CacheArgs {
                 // 3. Try to get from channel list cache
                 if let Some(channels) = GUILD_CHANNEL_LIST_CACHE.get(&self.guild_id).await {
                     // 4. If found, try to get the channel from the list
-                    channels
+                    return channels
                         .get(&self.channel_id)
                         .cloned()
-                        .ok_or_else(|| anyhow::anyhow!("Channel not found in cache"))?;
+                        .ok_or_else(|| anyhow::anyhow!("Channel not found in cache"));
                 }
 
                 // 5. If not found, fetch from API and update the cache
@@ -70,7 +63,7 @@ impl CacheArgs {
                             .iter()
                             .find(|t| t.id == self.channel_id)
                             .cloned()
-                            .ok_or(CacheError::CacheNotFound)?
+                            .ok_or_else(|| anyhow::anyhow!("Channel not found in cache"))?
                     }
                 };
 


### PR DESCRIPTION
As part of channel cache improvements, we have added caching functionality for channel lists.

Previously, babyrite only cached channels when performing the two retrieval processes triggered by a message quote request. Starting with v0.18.0, it now caches the channel list. For consecutive quote requests, it uses data stored in its own memory instead of accessing the Discord API.

The behavior in v0.18.0 and later is as follows:

1. Search for the target channel in the channel cache (If found, use that channel data)
2. Search the channel list cache for the target channel (If found, use that channel data)
3. If neither cache contains the data, use the Discord API to find the channel data
4. After all processing completes, cache each data set

Additionally, starting with v0.18.0, stored cache data is handled as follows:

- The maximum cache size is reduced from `1000` to `500` entries
- Entries are deleted from the cache after `1 hour` since last access
- Entries will be deleted `12 hours` after creation or update, regardless of whether they were accessed.

These changes are implemented to reduce memory usage, as babyrite is intended for use in small-scale bots (around 10 guilds).