### PR TITLE
fix(deps): Remove once_cell dependencies

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,10 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  "enable_language_server": true,
+  "format_on_save": "on",
+  "formatter": "language_server",
+  "language_servers": ["!biome", "rust-analyzer"],
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,6 @@ dependencies = [
  "dotenvy",
  "envy",
  "moka",
- "once_cell",
  "regex",
  "serde",
  "serenity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = "1.0.82"
 dotenvy = "0.15.7"
 envy = "0.4.2"
 moka = { version = "0.12.8", features = ["future"] }
-once_cell = "1.19.0"
 regex = "1.10.4"
 serde = { version = "1.0.200", features = ["derive"] }
 serenity = { version = "0.12.1", default-features = false, features = ["client", "gateway", "model", "cache", "rustls_backend"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -9,10 +9,10 @@
 
 use anyhow::Context as _;
 use moka::future::{Cache, CacheBuilder};
-use once_cell::sync::Lazy;
 use serenity::all::{ChannelId, GuildChannel, GuildId};
 use serenity::client::Context;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 /// Arguments for cache operations.
 pub struct CacheArgs {
@@ -25,8 +25,8 @@ pub struct CacheArgs {
 /// Cache for guild channel lists.
 ///
 /// Maps guild IDs to their channel lists. TTL: 12 hours, TTI: 1 hour.
-pub static GUILD_CHANNEL_LIST_CACHE: Lazy<Cache<GuildId, HashMap<ChannelId, GuildChannel>>> = {
-    Lazy::new(|| {
+pub static GUILD_CHANNEL_LIST_CACHE: LazyLock<Cache<GuildId, HashMap<ChannelId, GuildChannel>>> = {
+    LazyLock::new(|| {
         CacheBuilder::new(500)
             .name("guild_channel_list_cache")
             .time_to_idle(std::time::Duration::from_secs(3600))
@@ -38,8 +38,8 @@ pub static GUILD_CHANNEL_LIST_CACHE: Lazy<Cache<GuildId, HashMap<ChannelId, Guil
 /// Cache for individual guild channels.
 ///
 /// Maps channel IDs to their channel data. TTL: 12 hours, TTI: 1 hour.
-pub static GUILD_CHANNEL_CACHE: Lazy<Cache<ChannelId, GuildChannel>> = {
-    Lazy::new(|| {
+pub static GUILD_CHANNEL_CACHE: LazyLock<Cache<ChannelId, GuildChannel>> = {
+    LazyLock::new(|| {
         CacheBuilder::new(500)
             .name("guild_channel_cache")
             .time_to_idle(std::time::Duration::from_secs(3600))

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,9 +3,10 @@
 //! This module handles both environment variables and file-based configuration.
 
 use serde::Deserialize;
+use std::sync::OnceLock;
 
 /// Global configuration instance.
-pub static CONFIG: once_cell::sync::OnceCell<BabyriteConfig> = once_cell::sync::OnceCell::new();
+pub static CONFIG: OnceLock<BabyriteConfig> = OnceLock::new();
 
 /// Environment variable configuration.
 #[derive(Deserialize, Debug)]

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -3,9 +3,9 @@
 //! This module provides functionality for parsing Discord message links
 //! and generating previews of the linked messages.
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serenity::all::{ChannelId, ChannelType, Context, GuildChannel, GuildId, Message, MessageId};
+use std::sync::LazyLock;
 use url::Url;
 
 use crate::cache::CacheArgs;
@@ -13,7 +13,7 @@ use crate::cache::CacheArgs;
 /// Regex pattern for matching Discord message links.
 ///
 /// Supports production, PTB, and Canary Discord URLs.
-pub static MESSAGE_LINK_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static MESSAGE_LINK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"https://(?:ptb\.|canary\.)?discord\.com/channels/(\d+)/(\d+)/(\d+)").unwrap()
 });
 


### PR DESCRIPTION
Migrate to `std::sync::LazyLock` / `std::sync::OnceLock,` stabilized in Rust 1.80+, and remove the dependency on the `once_cell` crate.