### PR TITLE
feat: add code coverage with Codecov and initial unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,35 @@ jobs:
       - name: Run test
         run: cargo test --verbose
 
+  coverage:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          prefix-key: "babyrite/gh-actions-cache"
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@7f491e26f71f4ec2e6902c7c95c73043f209ab79 # v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          fail_ci_if_error: true
+
   build:
     name: build (${{ matrix.job.target }})
     runs-on: ${{ matrix.job.os || 'ubuntu-24.04' }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/m1sk9/babyrite/actions/workflows/ci.yaml/badge.svg)](https://github.com/m1sk9/babyrite/actions/workflows/ci.yaml)
 [![Release babyrite](https://github.com/m1sk9/babyrite/actions/workflows/release.yaml/badge.svg)](https://github.com/m1sk9/babyrite/actions/workflows/release.yaml)
 [![Apache License 2.0](https://img.shields.io/github/license/m1sk9/babyrite?color=%239944ee)](https://github.com/m1sk9/babyrite/blob/main/LICENSE)
+[![codecov](https://codecov.io/github/m1sk9/babyrite/graph/badge.svg?token=QA075J11S8)](https://codecov.io/github/m1sk9/babyrite)
 
 **babyrite** is a lightweight, fast citation message Discord bot.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,3 +145,89 @@ where
     let opt = Option::<String>::deserialize(deserializer)?;
     Ok(opt.filter(|s| !s.is_empty()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() {
+        let config = BabyriteConfig::default();
+        assert!(!config.json_logging);
+        assert!(config.features.github_permalink);
+        assert_eq!(config.github.max_lines, 50);
+    }
+
+    #[test]
+    fn deserialize_empty_config() {
+        let config: BabyriteConfig = toml::from_str("").unwrap();
+        assert!(!config.json_logging);
+        assert!(config.features.github_permalink);
+        assert_eq!(config.github.max_lines, 50);
+    }
+
+    #[test]
+    fn deserialize_full_config() {
+        let toml_str = r#"
+            json_logging = true
+
+            [features]
+            github_permalink = false
+
+            [github]
+            max_lines = 100
+        "#;
+        let config: BabyriteConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.json_logging);
+        assert!(!config.features.github_permalink);
+        assert_eq!(config.github.max_lines, 100);
+    }
+
+    #[test]
+    fn deserialize_partial_config() {
+        let toml_str = r#"
+            json_logging = true
+        "#;
+        let config: BabyriteConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.json_logging);
+        // defaults
+        assert!(config.features.github_permalink);
+        assert_eq!(config.github.max_lines, 50);
+    }
+
+    #[test]
+    fn empty_string_as_none_with_empty() {
+        #[derive(Deserialize)]
+        struct Test {
+            #[serde(default, deserialize_with = "empty_string_as_none")]
+            value: Option<String>,
+        }
+
+        let t: Test = toml::from_str(r#"value = """#).unwrap();
+        assert!(t.value.is_none());
+    }
+
+    #[test]
+    fn empty_string_as_none_with_value() {
+        #[derive(Deserialize)]
+        struct Test {
+            #[serde(default, deserialize_with = "empty_string_as_none")]
+            value: Option<String>,
+        }
+
+        let t: Test = toml::from_str(r#"value = "hello""#).unwrap();
+        assert_eq!(t.value.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn empty_string_as_none_absent() {
+        #[derive(Deserialize)]
+        struct Test {
+            #[serde(default, deserialize_with = "empty_string_as_none")]
+            value: Option<String>,
+        }
+
+        let t: Test = toml::from_str("").unwrap();
+        assert!(t.value.is_none());
+    }
+}

--- a/src/expand/discord.rs
+++ b/src/expand/discord.rs
@@ -167,3 +167,84 @@ impl Preview {
         Ok(Preview { message, channel })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_standard_link() {
+        let text = "https://discord.com/channels/123456789/987654321/111111111";
+        let results = MessageLinkIDs::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].guild_id, GuildId::new(123456789));
+        assert_eq!(results[0].channel_id, ChannelId::new(987654321));
+        assert_eq!(results[0].message_id, MessageId::new(111111111));
+    }
+
+    #[test]
+    fn parse_ptb_link() {
+        let text = "https://ptb.discord.com/channels/123/456/789";
+        let results = MessageLinkIDs::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].guild_id, GuildId::new(123));
+    }
+
+    #[test]
+    fn parse_canary_link() {
+        let text = "https://canary.discord.com/channels/123/456/789";
+        let results = MessageLinkIDs::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].guild_id, GuildId::new(123));
+    }
+
+    #[test]
+    fn parse_multiple_links() {
+        let text = "https://discord.com/channels/1/2/3 and https://discord.com/channels/4/5/6";
+        let results = MessageLinkIDs::parse_all(text);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].guild_id, GuildId::new(1));
+        assert_eq!(results[1].guild_id, GuildId::new(4));
+    }
+
+    #[test]
+    fn parse_deduplicates() {
+        let text = "https://discord.com/channels/1/2/3 https://discord.com/channels/1/2/3";
+        let results = MessageLinkIDs::parse_all(text);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn parse_limits_to_three() {
+        let text = "\
+            https://discord.com/channels/1/2/3 \
+            https://discord.com/channels/4/5/6 \
+            https://discord.com/channels/7/8/9 \
+            https://discord.com/channels/10/11/12";
+        let results = MessageLinkIDs::parse_all(text);
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn parse_no_match() {
+        let text = "Just some regular text";
+        let results = MessageLinkIDs::parse_all(text);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn parse_ignores_invalid_url() {
+        // Non-discord domain should not match (regex anchors to discord.com)
+        let text = "https://notdiscord.com/channels/1/2/3";
+        let results = MessageLinkIDs::parse_all(text);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn parse_mixed_with_text() {
+        let text = "Hey check this out https://discord.com/channels/1/2/3 pretty cool right?";
+        let results = MessageLinkIDs::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].message_id, MessageId::new(3));
+    }
+}

--- a/src/expand/github.rs
+++ b/src/expand/github.rs
@@ -213,3 +213,146 @@ fn truncate_lines(lines: &[&str], max: usize) -> (String, bool) {
         (lines.join("\n"), false)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- truncate_lines ---
+
+    #[test]
+    fn truncate_lines_under_limit() {
+        let lines = vec!["a", "b", "c"];
+        let (result, truncated) = truncate_lines(&lines, 5);
+        assert_eq!(result, "a\nb\nc");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncate_lines_at_limit() {
+        let lines = vec!["a", "b", "c"];
+        let (result, truncated) = truncate_lines(&lines, 3);
+        assert_eq!(result, "a\nb\nc");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncate_lines_over_limit() {
+        let lines = vec!["a", "b", "c", "d", "e"];
+        let (result, truncated) = truncate_lines(&lines, 2);
+        assert_eq!(result, "a\nb");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn truncate_lines_empty() {
+        let lines: Vec<&str> = vec![];
+        let (result, truncated) = truncate_lines(&lines, 5);
+        assert_eq!(result, "");
+        assert!(!truncated);
+    }
+
+    // --- GitHubPermalink::parse_all ---
+
+    #[test]
+    fn parse_basic_permalink() {
+        let text = "https://github.com/owner/repo/blob/abcdef1234567890abcdef1234567890abcdef12/src/main.rs";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].owner, "owner");
+        assert_eq!(results[0].repo, "repo");
+        assert_eq!(results[0].commit, "abcdef1234567890abcdef1234567890abcdef12");
+        assert_eq!(results[0].path, "src/main.rs");
+        assert!(results[0].line_range.is_none());
+    }
+
+    #[test]
+    fn parse_permalink_with_single_line() {
+        let text = "https://github.com/owner/repo/blob/abcd1234/src/lib.rs#L42";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 1);
+        let range = results[0].line_range.unwrap();
+        assert_eq!(range.start, 42);
+        assert_eq!(range.end, 42);
+    }
+
+    #[test]
+    fn parse_permalink_with_line_range() {
+        let text = "https://github.com/owner/repo/blob/abcd1234/src/lib.rs#L10-L20";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 1);
+        let range = results[0].line_range.unwrap();
+        assert_eq!(range.start, 10);
+        assert_eq!(range.end, 20);
+    }
+
+    #[test]
+    fn parse_rejects_branch_name() {
+        // Branch names (non-hex) should not match
+        let text = "https://github.com/owner/repo/blob/main/src/lib.rs";
+        let results = GitHubPermalink::parse_all(text);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn parse_rejects_short_sha() {
+        // SHA must be at least 4 hex characters
+        let text = "https://github.com/owner/repo/blob/abc/src/lib.rs";
+        let results = GitHubPermalink::parse_all(text);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn parse_deduplicates_urls() {
+        let text = "https://github.com/owner/repo/blob/abcd1234/src/lib.rs \
+                    https://github.com/owner/repo/blob/abcd1234/src/lib.rs";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn parse_limits_to_three() {
+        let text = "\
+            https://github.com/o/r/blob/aaaa1111/a.rs \
+            https://github.com/o/r/blob/bbbb2222/b.rs \
+            https://github.com/o/r/blob/cccc3333/c.rs \
+            https://github.com/o/r/blob/dddd4444/d.rs";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn parse_multiple_different_urls() {
+        let text = "Check https://github.com/a/b/blob/1111aaaa/x.rs#L1 and \
+                    https://github.com/c/d/blob/2222bbbb/y.py#L5-L10";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].owner, "a");
+        assert_eq!(results[1].owner, "c");
+        assert_eq!(results[1].path, "y.py");
+    }
+
+    #[test]
+    fn parse_no_match() {
+        let text = "Hello, no links here!";
+        let results = GitHubPermalink::parse_all(text);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn parse_nested_path() {
+        let text = "https://github.com/owner/repo/blob/abcd1234/src/deeply/nested/path/file.rs";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "src/deeply/nested/path/file.rs");
+    }
+
+    #[test]
+    fn parse_short_commit_sha() {
+        // 4-character SHA is the minimum
+        let text = "https://github.com/owner/repo/blob/abcd/file.rs";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].commit, "abcd");
+    }
+}

--- a/src/expand/github.rs
+++ b/src/expand/github.rs
@@ -261,7 +261,10 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].owner, "owner");
         assert_eq!(results[0].repo, "repo");
-        assert_eq!(results[0].commit, "abcdef1234567890abcdef1234567890abcdef12");
+        assert_eq!(
+            results[0].commit,
+            "abcdef1234567890abcdef1234567890abcdef12"
+        );
         assert_eq!(results[0].path, "src/main.rs");
         assert!(results[0].line_range.is_none());
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,3 +56,58 @@ pub fn language_from_extension(extension: &str) -> &str {
         _ => extension,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_extensions() {
+        assert_eq!(language_from_extension("rs"), "rust");
+        assert_eq!(language_from_extension("py"), "python");
+        assert_eq!(language_from_extension("js"), "javascript");
+        assert_eq!(language_from_extension("ts"), "typescript");
+        assert_eq!(language_from_extension("go"), "go");
+        assert_eq!(language_from_extension("java"), "java");
+        assert_eq!(language_from_extension("cpp"), "cpp");
+        assert_eq!(language_from_extension("cc"), "cpp");
+        assert_eq!(language_from_extension("c"), "c");
+        assert_eq!(language_from_extension("h"), "c");
+        assert_eq!(language_from_extension("hpp"), "cpp");
+        assert_eq!(language_from_extension("cs"), "csharp");
+        assert_eq!(language_from_extension("rb"), "ruby");
+        assert_eq!(language_from_extension("kt"), "kotlin");
+        assert_eq!(language_from_extension("kts"), "kotlin");
+        assert_eq!(language_from_extension("sh"), "bash");
+        assert_eq!(language_from_extension("bash"), "bash");
+        assert_eq!(language_from_extension("zsh"), "bash");
+        assert_eq!(language_from_extension("fish"), "bash");
+        assert_eq!(language_from_extension("yaml"), "yaml");
+        assert_eq!(language_from_extension("yml"), "yaml");
+        assert_eq!(language_from_extension("json"), "json");
+        assert_eq!(language_from_extension("toml"), "toml");
+        assert_eq!(language_from_extension("md"), "markdown");
+        assert_eq!(language_from_extension("ex"), "elixir");
+        assert_eq!(language_from_extension("exs"), "elixir");
+        assert_eq!(language_from_extension("hs"), "haskell");
+        assert_eq!(language_from_extension("tf"), "hcl");
+        assert_eq!(language_from_extension("vue"), "vue");
+        assert_eq!(language_from_extension("svelte"), "svelte");
+        assert_eq!(language_from_extension("proto"), "protobuf");
+        assert_eq!(language_from_extension("graphql"), "graphql");
+        assert_eq!(language_from_extension("gql"), "graphql");
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert_eq!(language_from_extension("RS"), "rust");
+        assert_eq!(language_from_extension("Py"), "python");
+        assert_eq!(language_from_extension("JS"), "javascript");
+    }
+
+    #[test]
+    fn unknown_extension_returns_as_is() {
+        assert_eq!(language_from_extension("xyz"), "xyz");
+        assert_eq!(language_from_extension("foo"), "foo");
+    }
+}


### PR DESCRIPTION
Add coverage CI job using cargo-llvm-cov and codecov-action (pinned by commit hash). Add 34 unit tests covering link parsing (Discord and GitHub), language detection, config deserialization, and line truncation.