### PR TITLE
fix: Extract filename from path before language detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,80 @@ docker pull ghcr.io/m1sk9/babyrite:v1.0.0
   well as publish it as OSS.
 - **Easy to Use**: babyrite is very easy to use and can be deployed in seconds.
 
+### Message Previews
+
+Detects Discord message links (`https://discord.com/channels/...`) and expands them as embedded content.
+
+- Supports Production, PTB, and Canary client URLs
+- Expands up to 3 links per message
+- Validates NSFW channels, permissions, and privacy
+
+### GitHub Permalink Expansion
+
+Detects GitHub permalinks (blob URLs containing a commit SHA) and expands file content as code blocks.
+
+- Supports line range specifications (`#L10-L20`)
+- Expands up to 3 links per message
+- 1MB file size limit; display truncated to 50 lines by default (configurable)
+
+<details>
+<summary>Supported languages</summary>
+
+| Extension | Language |
+| --- | --- |
+| `.rs` | Rust |
+| `.py` | Python |
+| `.js` | JavaScript |
+| `.ts` | TypeScript |
+| `.jsx` | JSX |
+| `.tsx` | TSX |
+| `.rb` | Ruby |
+| `.go` | Go |
+| `.java` | Java |
+| `.kt`, `.kts` | Kotlin |
+| `.c`, `.h` | C |
+| `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` | C++ |
+| `.cs` | C# |
+| `.swift` | Swift |
+| `.php` | PHP |
+| `.scala` | Scala |
+| `.sh`, `.bash`, `.zsh`, `.fish` | Bash |
+| `.ps1` | PowerShell |
+| `.html`, `.htm` | HTML |
+| `.css` | CSS |
+| `.scss` | SCSS |
+| `.sass` | Sass |
+| `.less` | Less |
+| `.json` | JSON |
+| `.yaml`, `.yml` | YAML |
+| `.toml` | TOML |
+| `.xml` | XML |
+| `.sql` | SQL |
+| `.md`, `.markdown` | Markdown |
+| `.lua` | Lua |
+| `.r` | R |
+| `.dart` | Dart |
+| `.zig` | Zig |
+| `.nim` | Nim |
+| `.ex`, `.exs` | Elixir |
+| `.erl`, `.hrl` | Erlang |
+| `.hs` | Haskell |
+| `.ml`, `.mli` | OCaml |
+| `.clj`, `.cljs` | Clojure |
+| `.tf` | HCL |
+| `.vue` | Vue |
+| `.svelte` | Svelte |
+| `.graphql`, `.gql` | GraphQL |
+| `.proto` | Protobuf |
+| `.mk`, `Makefile` | Makefile |
+| `Dockerfile` | Dockerfile |
+
+For extensions not listed above, the extension name is used as-is for the language hint. 
+
+Note that Discord code blocks use [highlight.js](https://highlightjs.org/) for syntax highlighting, so languages not supported by highlight.js cannot be highlighted regardless of babyrite's configuration. If syntax highlighting does not work correctly for a supported language, please [open an issue](https://github.com/m1sk9/babyrite/issues/new).
+
+</details>
+
 ## Installation
 
 You can install babyrite using Docker. The following command will pull the latest version of babyrite.

--- a/src/expand/github.rs
+++ b/src/expand/github.rs
@@ -177,12 +177,7 @@ impl GitHubPermalink {
         };
 
         let short_commit = &self.commit[..7.min(self.commit.len())];
-        let language = self
-            .path
-            .rsplit('.')
-            .next()
-            .map(language_from_extension)
-            .unwrap_or("");
+        let language = language_for_path(&self.path);
 
         let metadata = if line_info.is_empty() {
             format!(
@@ -201,6 +196,15 @@ impl GitHubPermalink {
             code,
             metadata,
         })
+    }
+}
+
+/// Extracts the filename from a path and returns the appropriate language identifier.
+fn language_for_path(path: &str) -> &str {
+    let filename = path.rsplit('/').next().unwrap_or(path);
+    match filename.rsplit_once('.') {
+        Some((_, ext)) => language_from_extension(ext),
+        None => language_from_extension(filename),
     }
 }
 
@@ -357,5 +361,37 @@ mod tests {
         let results = GitHubPermalink::parse_all(text);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].commit, "abcd");
+    }
+
+    // --- language_for_path ---
+
+    #[test]
+    fn language_for_path_basic_extension() {
+        assert_eq!(language_for_path("src/main.rs"), "rust");
+    }
+
+    #[test]
+    fn language_for_path_dockerfile_in_subdir() {
+        assert_eq!(language_for_path("docker/Dockerfile"), "dockerfile");
+    }
+
+    #[test]
+    fn language_for_path_dotted_directory() {
+        assert_eq!(language_for_path("some.config/Dockerfile"), "dockerfile");
+    }
+
+    #[test]
+    fn language_for_path_makefile_in_subdir() {
+        assert_eq!(language_for_path("build/Makefile"), "makefile");
+    }
+
+    #[test]
+    fn language_for_path_multiple_dots() {
+        assert_eq!(language_for_path("file.test.ts"), "typescript");
+    }
+
+    #[test]
+    fn language_for_path_dotfile() {
+        assert_eq!(language_for_path(".gitignore"), "gitignore");
     }
 }

--- a/src/expand/github.rs
+++ b/src/expand/github.rs
@@ -147,6 +147,11 @@ impl GitHubPermalink {
 
         let body = response.text().await.map_err(GitHubExpandError::Http)?;
 
+        Ok(self.build_code_block(&body, max_lines))
+    }
+
+    /// Builds an `ExpandedContent::CodeBlock` from raw file content.
+    fn build_code_block(&self, body: &str, max_lines: usize) -> ExpandedContent {
         let all_lines: Vec<&str> = body.lines().collect();
         let (code, line_info) = match self.line_range {
             Some(range) => {
@@ -191,11 +196,11 @@ impl GitHubPermalink {
             )
         };
 
-        Ok(ExpandedContent::CodeBlock {
+        ExpandedContent::CodeBlock {
             language: language.to_string(),
             code,
             metadata,
-        })
+        }
     }
 }
 
@@ -393,5 +398,121 @@ mod tests {
     #[test]
     fn language_for_path_dotfile() {
         assert_eq!(language_for_path(".gitignore"), "gitignore");
+    }
+
+    // --- build_code_block ---
+
+    fn make_permalink(path: &str, line_range: Option<LineRange>) -> GitHubPermalink {
+        GitHubPermalink {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            commit: "abcdef1234567".to_string(),
+            path: path.to_string(),
+            line_range,
+        }
+    }
+
+    #[test]
+    fn build_code_block_full_file() {
+        let permalink = make_permalink("src/main.rs", None);
+        let body = "fn main() {\n    println!(\"hello\");\n}";
+        let result = permalink.build_code_block(body, 50);
+
+        match result {
+            ExpandedContent::CodeBlock {
+                language,
+                code,
+                metadata,
+            } => {
+                assert_eq!(language, "rust");
+                assert_eq!(code, body);
+                assert_eq!(metadata, "`src/main.rs` - owner/repo@abcdef1");
+            }
+            _ => panic!("expected CodeBlock"),
+        }
+    }
+
+    #[test]
+    fn build_code_block_with_line_range() {
+        let permalink = make_permalink("src/lib.rs", Some(LineRange { start: 2, end: 3 }));
+        let body = "line1\nline2\nline3\nline4";
+        let result = permalink.build_code_block(body, 50);
+
+        match result {
+            ExpandedContent::CodeBlock {
+                language,
+                code,
+                metadata,
+            } => {
+                assert_eq!(language, "rust");
+                assert_eq!(code, "line2\nline3");
+                assert!(metadata.contains("L2-L3"));
+            }
+            _ => panic!("expected CodeBlock"),
+        }
+    }
+
+    #[test]
+    fn build_code_block_truncated() {
+        let permalink = make_permalink("app.py", None);
+        let body = "a\nb\nc\nd\ne";
+        let result = permalink.build_code_block(body, 2);
+
+        match result {
+            ExpandedContent::CodeBlock { code, metadata, .. } => {
+                assert_eq!(code, "a\nb");
+                assert!(metadata.contains("truncated to 2 lines"));
+            }
+            _ => panic!("expected CodeBlock"),
+        }
+    }
+
+    #[test]
+    fn build_code_block_line_range_truncated() {
+        let permalink = make_permalink("app.py", Some(LineRange { start: 1, end: 5 }));
+        let body = "a\nb\nc\nd\ne";
+        let result = permalink.build_code_block(body, 3);
+
+        match result {
+            ExpandedContent::CodeBlock { code, metadata, .. } => {
+                assert_eq!(code, "a\nb\nc");
+                assert!(metadata.contains("L1-L5"));
+                assert!(metadata.contains("truncated to 3 lines"));
+            }
+            _ => panic!("expected CodeBlock"),
+        }
+    }
+
+    #[test]
+    fn build_code_block_dockerfile_language() {
+        let permalink = make_permalink("docker/Dockerfile", None);
+        let body = "FROM rust:latest";
+        let result = permalink.build_code_block(body, 50);
+
+        match result {
+            ExpandedContent::CodeBlock { language, .. } => {
+                assert_eq!(language, "dockerfile");
+            }
+            _ => panic!("expected CodeBlock"),
+        }
+    }
+
+    #[test]
+    fn build_code_block_short_commit() {
+        let permalink = GitHubPermalink {
+            owner: "o".to_string(),
+            repo: "r".to_string(),
+            commit: "abcd".to_string(),
+            path: "f.rs".to_string(),
+            line_range: None,
+        };
+        let result = permalink.build_code_block("x", 50);
+
+        match result {
+            ExpandedContent::CodeBlock { metadata, .. } => {
+                assert!(metadata.contains("o/r@abcd"));
+            }
+            _ => panic!("expected CodeBlock"),
+        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -110,4 +110,12 @@ mod tests {
         assert_eq!(language_from_extension("xyz"), "xyz");
         assert_eq!(language_from_extension("foo"), "foo");
     }
+
+    #[test]
+    fn extensionless_filenames() {
+        assert_eq!(language_from_extension("Dockerfile"), "dockerfile");
+        assert_eq!(language_from_extension("dockerfile"), "dockerfile");
+        assert_eq!(language_from_extension("Makefile"), "makefile");
+        assert_eq!(language_from_extension("makefile"), "makefile");
+    }
 }


### PR DESCRIPTION
The previous logic ran rsplit('.') on the full path, causing incorrect language detection for extensionless files in subdirectories (e.g. "docker/Dockerfile", "some.config/Dockerfile"). Extract the filename component first via language_for_path() helper.