### PR TITLE
fix(github): ignore query string in permalink URLs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
         run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.json

--- a/src/expand/github.rs
+++ b/src/expand/github.rs
@@ -21,9 +21,13 @@ use crate::utils::language_from_extension;
 /// - `https://github.com/{owner}/{repo}/blob/{ref}/{path}#L{start}-L{end}`
 ///
 /// The `{ref}` can be a commit SHA (e.g., `abcdef1234567`) or a branch/tag name (e.g., `main`, `feature/foo`).
+///
+/// An optional query string (e.g., `?plain=1`) is consumed but discarded — GitHub's blob query
+/// parameters control browser rendering only and do not affect the raw content served by
+/// `raw.githubusercontent.com`.
 static GITHUB_PERMALINK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"https://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/([^#\s]+)(?:#L(\d+)(?:-L(\d+))?)?",
+        r"https://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/([^#\s?]+)(?:\?[^#\s]*)?(?:#L(\d+)(?:-L(\d+))?)?",
     )
     .unwrap()
 });
@@ -436,6 +440,55 @@ mod tests {
         let text = "Hello, no links here!";
         let results = GitHubPermalink::parse_all(text);
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn parse_permalink_with_query() {
+        let text = "https://github.com/owner/repo/blob/abcd1234/README.md?plain=1";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "README.md");
+        assert!(results[0].line_range.is_none());
+    }
+
+    #[test]
+    fn parse_permalink_with_query_and_line_range() {
+        // Regression test for issue #593: the URL reported in the issue.
+        let text = "https://github.com/m1sk9/dotfiles/blob/02962edfa2d9f5e1ed3f9a7cded1055b1a64b03d/private_dot_claude/CLAUDE.md?plain=1#L21-L46";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].owner, "m1sk9");
+        assert_eq!(results[0].repo, "dotfiles");
+        assert_eq!(
+            results[0].git_ref,
+            "02962edfa2d9f5e1ed3f9a7cded1055b1a64b03d"
+        );
+        assert_eq!(results[0].path, "private_dot_claude/CLAUDE.md");
+        let range = results[0].line_range.unwrap();
+        assert_eq!(range.start, 21);
+        assert_eq!(range.end, 46);
+    }
+
+    #[test]
+    fn parse_permalink_with_query_and_single_line() {
+        let text = "https://github.com/owner/repo/blob/abcd1234/src/lib.rs?plain=1#L10";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "src/lib.rs");
+        let range = results[0].line_range.unwrap();
+        assert_eq!(range.start, 10);
+        assert_eq!(range.end, 10);
+    }
+
+    #[test]
+    fn parse_permalink_with_multiple_query_params() {
+        let text = "https://github.com/owner/repo/blob/abcd1234/src/lib.rs?foo=bar&baz=qux#L1-L2";
+        let results = GitHubPermalink::parse_all(text);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "src/lib.rs");
+        let range = results[0].line_range.unwrap();
+        assert_eq!(range.start, 1);
+        assert_eq!(range.end, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- GitHub permalink の URL にクエリ（例: `?plain=1`）が含まれると，クエリ文字列がファイルパスの一部として捕捉され，`raw.githubusercontent.com` への取得 URL が壊れ，コードブロックのメタデータにも `md?plain=1` のように混入していた問題を修正
- 正規表現の path キャプチャから `?` を除外し，オプションのクエリ部分を非キャプチャグループで消費するように変更
- GitHub の blob クエリ（`?plain=1` 等）はブラウザ表示モードの切替で raw content には影響しないため，クエリは破棄して問題なし

Closes #593

## Test plan

- [x] issue #593 で報告された URL を直接検証する回帰テストを追加（\`parse_permalink_with_query_and_line_range\`）
- [x] \`?plain=1\` 単独・\`?plain=1#L10\`・複数クエリパラメータ（\`?foo=bar&baz=qux\`）のテストを追加
- [x] \`cargo test --verbose\` — 45 件すべて通過
- [x] \`cargo fmt --all -- --check\` — 通過
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — 通過

Generated with Claude Code