### PR TITLE
ci: resolve Node.js 20 deprecation and app-id warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
         run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.json

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload artifact
         id: babyrite_doc
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: target/doc
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: babyrite_doc
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,10 +11,6 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-24.04
-    env:
-      # googleapis/release-please-action@v4 still uses node20.
-      # Force Node.js 24 until upstream ships a node24-native version.
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       major: ${{ steps.release.outputs.major }}
@@ -31,14 +27,14 @@ jobs:
         id: babyrite-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           # Skip token revocation because expired tokens are automatically
           # invalidated by GitHub anyway.
           skip-token-revoke: true
 
       - name: Run release-please-action
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ steps.babyrite-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Resolve all deprecation warnings currently surfaced by GitHub Actions across `ci.yaml`, `release.yaml`, and `docs.yaml`.

## Changes
- `ci.yaml`: bump `codecov/codecov-action` from v5 (SHA pinned) to v7.0.0. The new release uses `actions/github-script@v8.0.0` internally (Node 24) and clears the Node 20 deprecation warning on the coverage job.
- `release.yaml`:
  - Bump `googleapis/release-please-action@v4` to `@v5` (native Node 24 since v5.0.0).
  - Drop the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env workaround now that the upstream ships a Node 24 build.
  - Switch `actions/create-github-app-token` input from `app-id: APP_ID` to `client-id: CLIENT_ID` (the `app-id` input emits a deprecation warning; the `CLIENT_ID` secret has already been provisioned).
- `docs.yaml`: bump `actions/upload-pages-artifact@v4` to `@v5` and `actions/deploy-pages@v4` to `@v5` (both use Node 24 from v5).

## Test plan
- [ ] CI run on this PR shows no Node 20 deprecation warnings.
- [ ] On merge to `main`, the Release workflow runs successfully with the `client-id` input and produces a release-please PR/commit as before.
- [ ] Deploy Docs workflow runs successfully on `main` push and publishes to GitHub Pages.

Generated with Claude Code