### PR TITLE
feat(reaction): add reaction-driven preview deletion

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -155,10 +155,12 @@ fn render_config(config: &BabyriteConfig) -> String {
          log.format: `{log_format}`\n\
          features.github_permalink: `{}`\n\
          features.commands: `{}`\n\
+         features.reactions: `{}`\n\
          github.max_lines: `{}`",
         config.log.level,
         config.features.github_permalink,
         config.features.commands,
+        config.features.reactions,
         config.github.max_lines,
     )
 }
@@ -421,6 +423,7 @@ mod tests {
         assert!(rendered.contains("log.format: `compact`"));
         assert!(rendered.contains("features.github_permalink: `true`"));
         assert!(rendered.contains("features.commands: `true`"));
+        assert!(rendered.contains("features.reactions: `true`"));
         assert!(rendered.contains("github.max_lines: `50`"));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,6 +105,11 @@ pub struct FeatureConfig {
     /// Defaults to `true`.
     #[serde(default = "default_true")]
     pub commands: bool,
+    /// Whether reaction-driven preview actions (e.g. deleting a preview via `🗑️`) are enabled.
+    ///
+    /// Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub reactions: bool,
 }
 
 impl Default for FeatureConfig {
@@ -112,6 +117,7 @@ impl Default for FeatureConfig {
         Self {
             github_permalink: default_true(),
             commands: default_true(),
+            reactions: default_true(),
         }
     }
 }
@@ -227,6 +233,7 @@ mod tests {
         assert_eq!(config.resolved_log_format(), LogFormat::Compact);
         assert!(config.features.github_permalink);
         assert!(config.features.commands);
+        assert!(config.features.reactions);
         assert_eq!(config.github.max_lines, 50);
     }
 
@@ -239,6 +246,7 @@ mod tests {
         assert_eq!(config.resolved_log_format(), LogFormat::Compact);
         assert!(config.features.github_permalink);
         assert!(config.features.commands);
+        assert!(config.features.reactions);
         assert_eq!(config.github.max_lines, 50);
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,7 +8,11 @@ use crate::config::BabyriteConfig;
 use crate::expand::ExpandedContent;
 use crate::expand::discord::MessageLinkIDs;
 use crate::expand::github::GitHubPermalink;
-use serenity::all::{ActivityData, Context, EventHandler, Message, Ready};
+use crate::reaction;
+use serenity::all::{
+    ActivityData, Context, CreateAllowedMentions, CreateMessage, EventHandler, Message,
+    Permissions, Reaction, ReactionType, Ready,
+};
 use serenity::prelude::TypeMapKey;
 use serenity_builder::model::message::{SerenityMessage, SerenityMessageMentionType};
 use tracing::Instrument;
@@ -156,10 +160,101 @@ impl EventHandler for BabyriteEventHandler {
         .instrument(span)
         .await;
     }
+
+    async fn reaction_add(&self, ctx: Context, reaction: Reaction) {
+        let config = BabyriteConfig::get();
+        if !config.features.reactions {
+            return;
+        }
+
+        let bot_id = ctx.cache.current_user().id;
+
+        // The bot's own delete reaction (attached right after sending a preview,
+        // see `attach_delete_reaction`) would otherwise re-trigger this handler.
+        if reaction.user_id == Some(bot_id) {
+            return;
+        }
+
+        // Unrecognized emoji are ignored outright — this is the entire
+        // enforcement of "every reaction except the recognized ones is ignored".
+        let Some(action) = reaction::from_emoji(&reaction.emoji) else {
+            return;
+        };
+
+        // Only previews the bot itself sent are valid action targets. Checking
+        // via the gateway payload's `message_author_id` (present on ReactionAdd)
+        // avoids fetching the message for the common case of a reaction on
+        // someone else's message.
+        if reaction.message_author_id != Some(bot_id) {
+            return;
+        }
+
+        let (Some(guild_id), Some(reactor_id)) = (reaction.guild_id, reaction.user_id) else {
+            return;
+        };
+
+        let span = tracing::info_span!(
+            "reaction_add",
+            guild_id = %guild_id,
+            channel_id = %reaction.channel_id,
+            message_id = %reaction.message_id,
+            reactor = %reactor_id,
+        );
+
+        async {
+            let preview = match reaction.message(&ctx.http).await {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::error!(error = ?e, "failed to fetch reacted-to preview");
+                    return;
+                }
+            };
+
+            // Previews are sent as replies to their request (see
+            // `send_expanded_contents`), so the requester is read back from
+            // `referenced_message` rather than kept in separate state — this
+            // is what lets a preview stay actionable across a bot restart.
+            let requester = preview.referenced_message.as_deref().map(|m| m.author.id);
+
+            // `member` is only needed for the MANAGE_MESSAGES check below, not
+            // for the requester-self-delete path — so its absence must not
+            // block a requester from deleting their own preview.
+            let can_manage_messages = match reaction.member.as_ref() {
+                Some(member) => match (CacheArgs {
+                    guild_id,
+                    channel_id: reaction.channel_id,
+                })
+                .get(&ctx)
+                .await
+                {
+                    Ok(channel) => ctx.cache.guild(guild_id).is_some_and(|guild| {
+                        guild
+                            .user_permissions_in(&channel, member)
+                            .contains(Permissions::MANAGE_MESSAGES)
+                    }),
+                    Err(e) => {
+                        tracing::error!(error = %e, "failed to resolve channel for permission check");
+                        false
+                    }
+                },
+                None => false,
+            };
+
+            if !reaction::is_authorized(requester, reactor_id, can_manage_messages) {
+                tracing::debug!("reactor is not authorized to trigger this action");
+                return;
+            }
+
+            reaction::execute(&ctx, &preview, action).await;
+        }
+        .instrument(span)
+        .await;
+    }
 }
 
 /// Sends expanded contents as a reply to the original message.
 async fn send_expanded_contents(ctx: &Context, request: &Message, results: Vec<ExpandedContent>) {
+    let config = BabyriteConfig::get();
     let mut embeds = Vec::new();
     let mut code_blocks = Vec::new();
 
@@ -194,20 +289,33 @@ async fn send_expanded_contents(ctx: &Context, request: &Message, results: Vec<E
             }
         };
 
-        if let Err(e) = request
+        match request
             .channel_id
             .send_message(&ctx.http, converted_message)
             .await
         {
-            tracing::error!(error = ?e, "failed to send preview");
-            return;
+            Ok(sent) => attach_delete_reaction(ctx, &sent, config).await,
+            Err(e) => {
+                tracing::error!(error = ?e, "failed to send preview");
+                return;
+            }
         }
     }
 
-    // Send code blocks as plain messages
+    // Code blocks are sent as replies rather than plain messages (as `.say`
+    // would) so that, like the embed path above, a reaction on the sent
+    // preview can look up its `referenced_message` to find who requested it
+    // — see `EventHandler::reaction_add`. `allowed_mentions` is left empty so
+    // this doesn't newly ping the requester on every reply.
     for block in code_blocks {
-        if let Err(e) = request.channel_id.say(&ctx.http, &block).await {
-            tracing::error!(error = ?e, "failed to send code block");
+        let message = CreateMessage::new()
+            .content(&block)
+            .reference_message(request)
+            .allowed_mentions(CreateAllowedMentions::new());
+
+        match request.channel_id.send_message(&ctx.http, message).await {
+            Ok(sent) => attach_delete_reaction(ctx, &sent, config).await,
+            Err(e) => tracing::error!(error = ?e, "failed to send code block"),
         }
     }
 
@@ -216,4 +324,24 @@ async fn send_expanded_contents(ctx: &Context, request: &Message, results: Vec<E
         code_blocks = code_block_count,
         "preview sent"
     );
+}
+
+/// Attaches the delete-preview reaction to a freshly-sent preview message.
+///
+/// A no-op when the reactions feature is disabled, so a disabled feature
+/// doesn't leave stray reactions that then do nothing when pressed.
+async fn attach_delete_reaction(ctx: &Context, preview: &Message, config: &BabyriteConfig) {
+    if !config.features.reactions {
+        return;
+    }
+
+    if let Err(e) = preview
+        .react(
+            &ctx.http,
+            ReactionType::Unicode(reaction::DELETE_PREVIEW_EMOJI.to_string()),
+        )
+        .await
+    {
+        tracing::error!(error = ?e, "failed to attach delete reaction to preview");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod command;
 mod config;
 mod event;
 mod expand;
+mod reaction;
 mod utils;
 
 use crate::{
@@ -43,7 +44,10 @@ async fn main() -> anyhow::Result<()> {
 
     let mut client = serenity::Client::builder(
         &envs.discord_api_token,
-        GatewayIntents::MESSAGE_CONTENT | GatewayIntents::GUILD_MESSAGES | GatewayIntents::GUILDS,
+        GatewayIntents::MESSAGE_CONTENT
+            | GatewayIntents::GUILD_MESSAGES
+            | GatewayIntents::GUILDS
+            | GatewayIntents::GUILD_MESSAGE_REACTIONS,
     )
     .event_handler(BabyriteEventHandler)
     .await

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -1,0 +1,137 @@
+//! Reaction-driven actions on bot-sent previews.
+//!
+//! A preview posted by the bot carries a reaction (e.g. `🗑️`) that, when
+//! pressed by an authorized member, triggers an action on that preview. This
+//! module is the mapping from "which emoji" to "which action" plus the
+//! authorization rule; `event.rs` wires it to the `reaction_add` gateway
+//! event and the Discord API calls needed to carry an action out.
+//!
+//! Adding a new reaction action means adding a variant to [`ReactionAction`],
+//! a case in [`from_emoji`], and a case in [`execute`] — the gateway-side
+//! wiring in `event.rs` does not need to change.
+
+use serenity::all::{Context, Message, ReactionType, UserId};
+
+/// A recognized reaction action.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ReactionAction {
+    /// Delete the bot's preview message.
+    DeletePreview,
+}
+
+/// The emoji that triggers [`ReactionAction::DeletePreview`].
+///
+/// `pub(crate)` rather than private: `event.rs` attaches this same emoji to a
+/// freshly-sent preview, and reusing the constant keeps the two ends
+/// (attaching the reaction, recognizing it) from drifting apart.
+pub(crate) const DELETE_PREVIEW_EMOJI: &str = "🗑️";
+
+/// Maps a reaction emoji to a [`ReactionAction`].
+///
+/// Returns `None` for anything other than the recognized emoji — including
+/// custom guild emoji. That `None` is what "every other reaction is ignored"
+/// reduces to: an unrecognized emoji simply never reaches an action.
+pub fn from_emoji(emoji: &ReactionType) -> Option<ReactionAction> {
+    let ReactionType::Unicode(unicode) = emoji else {
+        return None;
+    };
+
+    // Discord clients are inconsistent about sending the variation selector
+    // (U+FE0F) after the base emoji, so it's stripped from both sides before
+    // comparing rather than requiring an exact byte match.
+    let strip_vs16 = |s: &str| -> String { s.chars().filter(|&c| c != '\u{FE0F}').collect() };
+
+    (strip_vs16(unicode) == strip_vs16(DELETE_PREVIEW_EMOJI))
+        .then_some(ReactionAction::DeletePreview)
+}
+
+/// Decides whether `reactor` may trigger a reaction action.
+///
+/// Authorized when the reactor is the original preview requester, or holds
+/// `MANAGE_MESSAGES`. When the requester can't be determined (`requester` is
+/// `None`), only the permission grants access — this is stricter than
+/// treating an unresolved requester as "nobody to exclude", which would let
+/// any member act on such a preview.
+pub fn is_authorized(
+    requester: Option<UserId>,
+    reactor: UserId,
+    reactor_can_manage_messages: bool,
+) -> bool {
+    requester == Some(reactor) || reactor_can_manage_messages
+}
+
+/// Executes `action` against the preview message that was reacted to.
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub async fn execute(ctx: &Context, preview: &Message, action: ReactionAction) {
+    match action {
+        ReactionAction::DeletePreview => {
+            if let Err(e) = preview.delete(&ctx.http).await {
+                tracing::error!(error = ?e, "failed to delete preview");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serenity::all::EmojiId;
+
+    fn user(id: u64) -> UserId {
+        UserId::new(id)
+    }
+
+    #[test]
+    fn from_emoji_recognizes_the_fully_qualified_trash_emoji() {
+        let emoji = ReactionType::Unicode("🗑️".to_string());
+        assert_eq!(from_emoji(&emoji), Some(ReactionAction::DeletePreview));
+    }
+
+    #[test]
+    fn from_emoji_recognizes_the_trash_emoji_without_a_variation_selector() {
+        // Some clients send U+1F5D1 alone, without the trailing U+FE0F.
+        let emoji = ReactionType::Unicode("\u{1F5D1}".to_string());
+        assert_eq!(from_emoji(&emoji), Some(ReactionAction::DeletePreview));
+    }
+
+    #[test]
+    fn from_emoji_ignores_unrelated_unicode_emoji() {
+        let emoji = ReactionType::Unicode("👍".to_string());
+        assert_eq!(from_emoji(&emoji), None);
+    }
+
+    #[test]
+    fn from_emoji_ignores_custom_guild_emoji() {
+        let emoji = ReactionType::Custom {
+            animated: false,
+            id: EmojiId::new(123),
+            name: Some("custom".to_string()),
+        };
+        assert_eq!(from_emoji(&emoji), None);
+    }
+
+    #[test]
+    fn is_authorized_allows_the_original_requester() {
+        assert!(is_authorized(Some(user(1)), user(1), false));
+    }
+
+    #[test]
+    fn is_authorized_allows_a_manage_messages_holder() {
+        assert!(is_authorized(Some(user(1)), user(2), true));
+    }
+
+    #[test]
+    fn is_authorized_rejects_an_unrelated_reactor_without_permission() {
+        assert!(!is_authorized(Some(user(1)), user(2), false));
+    }
+
+    #[test]
+    fn is_authorized_rejects_an_unknown_requester_without_permission() {
+        assert!(!is_authorized(None, user(2), false));
+    }
+
+    #[test]
+    fn is_authorized_allows_an_unknown_requester_with_permission() {
+        assert!(is_authorized(None, user(2), true));
+    }
+}


### PR DESCRIPTION
## Summary

- Attach a `🗑️` reaction to every preview the bot sends; pressing it deletes that preview.
- Authorized reactors: the original preview requester, or a member with `MANAGE_MESSAGES`. All other reactions are ignored.
- `src/reaction.rs` (new): `ReactionAction` enum + `from_emoji`/`is_authorized` as pure, unit-tested functions, plus `execute` for the Discord API call. Adding a future reaction action only touches this module.
- Requester identification is stateless: previews are sent as replies to the request, and the requester is read back from `referenced_message` when the reaction fires — no separate cache, so this survives a bot restart. This is why GitHub code block previews (previously sent via `.say`, with no reply reference) are now sent as replies too.
- New `features.reactions` config flag (defaults to `true`, backward compatible) and the `GUILD_MESSAGE_REACTIONS` gateway intent.

## Test plan

- [x] `cargo build`
- [x] `cargo test --verbose` (111 passed, including new `reaction::tests` covering `from_emoji` emoji matching/variation-selector handling and `is_authorized` authorization matrix)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`
- [ ] Live verification on a Discord server: preview gets `🗑️`, requester can delete, unrelated members cannot, a `MANAGE_MESSAGES` holder can, non-`🗑️` reactions are no-ops, deletion still works after a bot restart — not yet run, since this requires a live bot/server.

Note: the bot needs the `ADD_REACTIONS` and `READ_MESSAGE_HISTORY` Discord permissions in addition to `MANAGE_MESSAGES` for the delete action itself.

Generated by Claude Code