### PR TITLE
refactor: consolidate link expansion behind a LinkExpander trait and tidy shared logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "typed-builder",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ toml = "1.0.0"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 typed-builder = "0.23.0"
-url = "2.5.2"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -22,31 +22,27 @@ pub struct CacheArgs {
     pub channel_id: ChannelId,
 }
 
-/// Cache for guild channel lists.
-///
-/// Maps guild IDs to their channel lists. TTL: 12 hours, TTI: 1 hour.
-pub static GUILD_CHANNEL_LIST_CACHE: LazyLock<Cache<GuildId, HashMap<ChannelId, GuildChannel>>> = {
-    LazyLock::new(|| {
-        CacheBuilder::new(500)
-            .name("guild_channel_list_cache")
-            .time_to_idle(std::time::Duration::from_secs(3600))
-            .time_to_live(std::time::Duration::from_secs(43200))
-            .build()
-    })
-};
+/// Builds a cache with the shared tuning for both channel caches:
+/// 500 entries, TTL 12 hours, TTI 1 hour.
+fn channel_cache<K, V>(name: &str) -> Cache<K, V>
+where
+    K: std::hash::Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    CacheBuilder::new(500)
+        .name(name)
+        .time_to_idle(std::time::Duration::from_secs(3600))
+        .time_to_live(std::time::Duration::from_secs(43200))
+        .build()
+}
 
-/// Cache for individual guild channels.
-///
-/// Maps channel IDs to their channel data. TTL: 12 hours, TTI: 1 hour.
-pub static GUILD_CHANNEL_CACHE: LazyLock<Cache<ChannelId, GuildChannel>> = {
-    LazyLock::new(|| {
-        CacheBuilder::new(500)
-            .name("guild_channel_cache")
-            .time_to_idle(std::time::Duration::from_secs(3600))
-            .time_to_live(std::time::Duration::from_secs(43200))
-            .build()
-    })
-};
+/// Cache for guild channel lists, mapping guild IDs to their channel lists.
+pub static GUILD_CHANNEL_LIST_CACHE: LazyLock<Cache<GuildId, HashMap<ChannelId, GuildChannel>>> =
+    LazyLock::new(|| channel_cache("guild_channel_list_cache"));
+
+/// Cache for individual guild channels, mapping channel IDs to their channel data.
+pub static GUILD_CHANNEL_CACHE: LazyLock<Cache<ChannelId, GuildChannel>> =
+    LazyLock::new(|| channel_cache("guild_channel_cache"));
 
 impl CacheArgs {
     /// Retrieves a guild channel from cache or fetches it from the API.
@@ -60,54 +56,53 @@ impl CacheArgs {
         fields(guild_id = %self.guild_id, channel_id = %self.channel_id)
     )]
     pub async fn get(&self, ctx: &Context) -> anyhow::Result<GuildChannel> {
-        match GUILD_CHANNEL_CACHE.get(&self.channel_id).await {
-            Some(channel) => {
-                tracing::debug!("channel cache hit");
-                Ok(channel)
-            }
-            None => {
-                tracing::debug!("channel cache miss");
-                let channel_list =
-                    if let Some(channels) = GUILD_CHANNEL_LIST_CACHE.get(&self.guild_id).await {
-                        tracing::debug!("guild channel list cache hit");
-                        channels
-                    } else {
-                        tracing::debug!("guild channel list cache miss");
-                        self.get_channel_list_from_api(ctx).await?
-                    };
-
-                let channel = match channel_list.get(&self.channel_id).cloned() {
-                    Some(c) => c,
-                    None => {
-                        // Not in the channel list — it may be an active thread,
-                        // which is not returned by the guild channels endpoint.
-                        tracing::debug!("channel not in list, searching active threads");
-                        let data = self
-                            .guild_id
-                            .get_active_threads(&ctx.http)
-                            .await
-                            .context("Failed to get active threads")?;
-                        data.threads
-                            .iter()
-                            .find(|t| t.id == self.channel_id)
-                            .cloned()
-                            .ok_or_else(|| {
-                                tracing::debug!("channel not found in guild or active threads");
-                                anyhow::anyhow!("Channel not found in cache")
-                            })?
-                    }
-                };
-
-                GUILD_CHANNEL_CACHE
-                    .insert(self.channel_id, channel.clone())
-                    .await;
-                tracing::trace!("inserted channel into cache");
-                Ok(channel)
-            }
+        if let Some(channel) = GUILD_CHANNEL_CACHE.get(&self.channel_id).await {
+            tracing::debug!("channel cache hit");
+            return Ok(channel);
         }
+        tracing::debug!("channel cache miss");
+
+        // `try_get_with` coalesces concurrent misses for the same guild into a
+        // single fetch, so `join_all`-ing several link expansions no longer
+        // fires one identical `channels` request per link.
+        let channel_list = GUILD_CHANNEL_LIST_CACHE
+            .try_get_with(self.guild_id, self.get_channel_list_from_api(ctx))
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get channel list: {e}"))?;
+
+        let channel = match channel_list.get(&self.channel_id).cloned() {
+            Some(c) => c,
+            None => {
+                // Not in the channel list — it may be an active thread,
+                // which is not returned by the guild channels endpoint.
+                tracing::debug!("channel not in list, searching active threads");
+                let data = self
+                    .guild_id
+                    .get_active_threads(&ctx.http)
+                    .await
+                    .context("Failed to get active threads")?;
+                data.threads
+                    .iter()
+                    .find(|t| t.id == self.channel_id)
+                    .cloned()
+                    .ok_or_else(|| {
+                        tracing::debug!("channel not found in guild or active threads");
+                        anyhow::anyhow!("Channel not found in cache")
+                    })?
+            }
+        };
+
+        GUILD_CHANNEL_CACHE
+            .insert(self.channel_id, channel.clone())
+            .await;
+        tracing::trace!("inserted channel into cache");
+        Ok(channel)
     }
 
-    /// Fetches the channel list from the Discord API and updates the cache.
+    /// Fetches the channel list from the Discord API.
+    ///
+    /// The caller inserts the result into [`GUILD_CHANNEL_LIST_CACHE`] via
+    /// `try_get_with`, so this does not touch the cache itself.
     #[tracing::instrument(skip(self, ctx), fields(guild_id = %self.guild_id))]
     async fn get_channel_list_from_api(
         &self,
@@ -115,19 +110,12 @@ impl CacheArgs {
     ) -> anyhow::Result<HashMap<ChannelId, GuildChannel>> {
         tracing::debug!("fetching channel list from Discord API");
         let started = std::time::Instant::now();
-        let guild = ctx
-            .http
-            .get_guild(self.guild_id)
-            .await
-            .context("Failed to get guild")?;
-        let channels = guild
-            .channels(&ctx)
+        let channels = self
+            .guild_id
+            .channels(&ctx.http)
             .await
             .context("Failed to get channel list")?;
 
-        GUILD_CHANNEL_LIST_CACHE
-            .insert(self.guild_id, channels.clone())
-            .await;
         tracing::debug!(
             channels = channels.len(),
             elapsed_ms = started.elapsed().as_millis(),

--- a/src/command.rs
+++ b/src/command.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 
 /// TypeMap key for the shared shard manager.
 ///
-/// Registered alongside [`crate::event::HttpClient`] so the `ping` command
+/// Registered alongside [`crate::expand::github::HttpClient`] so the `ping` command
 /// can read the gateway heartbeat latency for the shard handling this event.
 pub struct ShardManagerContainer;
 
@@ -58,8 +58,11 @@ pub fn parse(content: &str, bot_id: UserId) -> Option<Command> {
         return Some(Command::Help);
     }
 
-    let head_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
-    let head = rest[..head_end].to_ascii_lowercase();
+    let head = rest
+        .split_whitespace()
+        .next()
+        .unwrap_or(rest)
+        .to_ascii_lowercase();
 
     match head.as_str() {
         "version" => Some(Command::Version),
@@ -244,12 +247,7 @@ async fn execute_ping(ctx: &Context, request: &Message) {
     let gateway_text = format_latency(gateway_latency);
 
     let start = Instant::now();
-    let Some(mut sent) = send_reply(
-        ctx,
-        request,
-        &format!("🏓 Pong!\nGateway latency: {gateway_text}\nAPI latency: measuring…"),
-    )
-    .await
+    let Some(mut sent) = send_reply(ctx, request, &render_pong(&gateway_text, "measuring…")).await
     else {
         return;
     };
@@ -258,15 +256,21 @@ async fn execute_ping(ctx: &Context, request: &Message) {
     if let Err(e) = sent
         .edit(
             ctx,
-            EditMessage::new().content(format!(
-                "🏓 Pong!\nGateway latency: {gateway_text}\nAPI latency: {}ms",
-                api_latency.as_millis()
+            EditMessage::new().content(render_pong(
+                &gateway_text,
+                &format_latency(Some(api_latency)),
             )),
         )
         .await
     {
         tracing::error!(error = ?e, "failed to update ping latency");
     }
+}
+
+/// Renders the `ping` reply body; used for both the initial send and the
+/// latency edit so the two stay in sync.
+fn render_pong(gateway_text: &str, api_text: &str) -> String {
+    format!("🏓 Pong!\nGateway latency: {gateway_text}\nAPI latency: {api_text}")
 }
 
 fn format_latency(latency: Option<Duration>) -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,24 +57,24 @@ pub struct BabyriteConfig {
 /// Logging configuration.
 ///
 /// Controls the log level filter and output format.
+/// Missing fields fall back to [`LogConfig::default`].
 #[derive(Deserialize, Debug)]
+#[serde(default)]
 pub struct LogConfig {
     /// Tracing filter directive used when `RUST_LOG` is not set.
     ///
     /// Accepts the same syntax as `RUST_LOG` (e.g. `babyrite=debug`).
     /// Defaults to `babyrite=info`.
-    #[serde(default = "default_log_level")]
     pub level: String,
     /// Output format. When unset, falls back to the deprecated `json_logging`
     /// flag (see [`BabyriteConfig::resolved_log_format`]).
-    #[serde(default)]
     pub format: Option<LogFormat>,
 }
 
 impl Default for LogConfig {
     fn default() -> Self {
         Self {
-            level: default_log_level(),
+            level: "babyrite=info".to_string(),
             format: None,
         }
     }
@@ -93,57 +93,45 @@ pub enum LogFormat {
 /// Feature flags configuration.
 ///
 /// Controls which link expansion features are enabled.
+/// Missing fields fall back to [`FeatureConfig::default`].
 #[derive(Deserialize, Debug)]
+#[serde(default)]
 pub struct FeatureConfig {
     /// Whether GitHub Permalink expansion is enabled.
     ///
     /// Defaults to `true`.
-    #[serde(default = "default_true")]
     pub github_permalink: bool,
     /// Whether the mention-prefixed command system (`version`, `ping`, etc.) is enabled.
     ///
     /// Defaults to `true`.
-    #[serde(default = "default_true")]
     pub commands: bool,
 }
 
 impl Default for FeatureConfig {
     fn default() -> Self {
         Self {
-            github_permalink: default_true(),
-            commands: default_true(),
+            github_permalink: true,
+            commands: true,
         }
     }
 }
 
 /// GitHub-related configuration.
+///
+/// Missing fields fall back to [`GitHubConfig::default`].
 #[derive(Deserialize, Debug)]
+#[serde(default)]
 pub struct GitHubConfig {
     /// Maximum number of lines to display without truncation.
     ///
     /// Defaults to `50`.
-    #[serde(default = "default_max_lines")]
     pub max_lines: usize,
 }
 
 impl Default for GitHubConfig {
     fn default() -> Self {
-        Self {
-            max_lines: default_max_lines(),
-        }
+        Self { max_lines: 50 }
     }
-}
-
-fn default_true() -> bool {
-    true
-}
-
-fn default_max_lines() -> usize {
-    50
-}
-
-fn default_log_level() -> String {
-    "babyrite=info".to_string()
 }
 
 /// Errors that can occur when loading configuration.
@@ -165,19 +153,15 @@ impl BabyriteConfig {
     ///
     /// Loads configuration from a file if `CONFIG_FILE_PATH` is set,
     /// otherwise uses default values.
-    pub fn init() -> anyhow::Result<(), BabyriteConfigError> {
-        let envs = EnvConfig::get();
-        match &envs.config_file_path {
+    pub fn init() -> Result<(), BabyriteConfigError> {
+        let config = match &EnvConfig::get().config_file_path {
             Some(p) => {
-                let buffer = &std::fs::read_to_string(p).map_err(|_| BabyriteConfigError::Read)?;
-                let config: BabyriteConfig =
-                    toml::from_str(buffer).map_err(|_| BabyriteConfigError::Parse)?;
-                Ok(CONFIG.set(config).map_err(|_| BabyriteConfigError::Parse)?)
+                let buffer = std::fs::read_to_string(p).map_err(|_| BabyriteConfigError::Read)?;
+                toml::from_str(&buffer).map_err(|_| BabyriteConfigError::Parse)?
             }
-            None => Ok(CONFIG
-                .set(BabyriteConfig::default())
-                .map_err(|_| BabyriteConfigError::Set)?),
-        }
+            None => BabyriteConfig::default(),
+        };
+        CONFIG.set(config).map_err(|_| BabyriteConfigError::Set)
     }
 
     /// Returns a reference to the global configuration.
@@ -309,39 +293,27 @@ mod tests {
         assert_eq!(config.github.max_lines, 50);
     }
 
+    #[derive(Deserialize)]
+    struct EmptyStringAsNone {
+        #[serde(default, deserialize_with = "empty_string_as_none")]
+        value: Option<String>,
+    }
+
     #[test]
     fn empty_string_as_none_with_empty() {
-        #[derive(Deserialize)]
-        struct Test {
-            #[serde(default, deserialize_with = "empty_string_as_none")]
-            value: Option<String>,
-        }
-
-        let t: Test = toml::from_str(r#"value = """#).unwrap();
+        let t: EmptyStringAsNone = toml::from_str(r#"value = """#).unwrap();
         assert!(t.value.is_none());
     }
 
     #[test]
     fn empty_string_as_none_with_value() {
-        #[derive(Deserialize)]
-        struct Test {
-            #[serde(default, deserialize_with = "empty_string_as_none")]
-            value: Option<String>,
-        }
-
-        let t: Test = toml::from_str(r#"value = "hello""#).unwrap();
+        let t: EmptyStringAsNone = toml::from_str(r#"value = "hello""#).unwrap();
         assert_eq!(t.value.as_deref(), Some("hello"));
     }
 
     #[test]
     fn empty_string_as_none_absent() {
-        #[derive(Deserialize)]
-        struct Test {
-            #[serde(default, deserialize_with = "empty_string_as_none")]
-            value: Option<String>,
-        }
-
-        let t: Test = toml::from_str("").unwrap();
+        let t: EmptyStringAsNone = toml::from_str("").unwrap();
         assert!(t.value.is_none());
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,22 +3,12 @@
 //! This module implements the serenity [`EventHandler`] trait to handle
 //! Discord gateway events such as ready and message events.
 
-use crate::cache::CacheArgs;
 use crate::config::BabyriteConfig;
-use crate::expand::ExpandedContent;
-use crate::expand::discord::MessageLinkIDs;
-use crate::expand::github::GitHubPermalink;
+use crate::expand::{EXPANDERS, ExpandContext, ExpandedContent};
 use serenity::all::{ActivityData, Context, EventHandler, Message, Ready};
-use serenity::prelude::TypeMapKey;
+use serenity::futures::future::join_all;
 use serenity_builder::model::message::{SerenityMessage, SerenityMessageMentionType};
 use tracing::Instrument;
-
-/// TypeMap key for the shared reqwest HTTP client.
-pub struct HttpClient;
-
-impl TypeMapKey for HttpClient {
-    type Value = reqwest::Client;
-}
 
 /// Event handler for Babyrite bot.
 pub struct BabyriteEventHandler;
@@ -36,9 +26,8 @@ impl EventHandler for BabyriteEventHandler {
             return;
         }
 
-        let request_guild_id = match request.guild_id {
-            Some(id) => id,
-            None => return,
+        let Some(request_guild_id) = request.guild_id else {
+            return;
         };
 
         // Correlation span: every log emitted while handling this message
@@ -70,81 +59,34 @@ impl EventHandler for BabyriteEventHandler {
                 match crate::command::parse(text, bot_id) {
                     Some(crate::command::Command::Unknown(word)) => unknown_command = Some(word),
                     Some(command) => {
-                        tracing::debug!(?command, "handling mention command");
-                        crate::command::execute(&ctx, &request, command).await;
+                        dispatch_command(&ctx, &request, command).await;
                         return;
                     }
                     None => {}
                 }
             }
 
-            let mut results = Vec::new();
-
-            // Discord link expansion
-            let discord_links = MessageLinkIDs::parse_all(text);
-            if !discord_links.is_empty() {
-                tracing::debug!(count = discord_links.len(), "parsed Discord links");
-                // Resolve the source channel once. The expanded preview is posted here,
-                // so it is needed to verify the link target is at least as visible as
-                // this channel. If it cannot be resolved, skip Discord expansion (but
-                // still allow GitHub expansion below).
-                match (CacheArgs {
-                    guild_id: request_guild_id,
-                    channel_id: request.channel_id,
-                })
-                .get(&ctx)
-                .await
-                {
-                    Ok(source_channel) => {
-                        for ids in discord_links {
-                            if ids.guild_id != request_guild_id {
-                                tracing::debug!(
-                                    link_guild_id = %ids.guild_id,
-                                    "skipping cross-guild Discord link"
-                                );
-                                continue;
-                            }
-
-                            match ids.fetch(&ctx, &source_channel).await {
-                                Ok(content) => results.push(content),
-                                Err(e) => {
-                                    tracing::error!(error = %e, "failed to expand Discord link")
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, "failed to resolve source channel");
-                    }
-                }
-            }
-
-            // GitHub Permalink expansion (can be disabled via config)
-            if config.features.github_permalink {
-                let permalinks = GitHubPermalink::parse_all(text);
-                if !permalinks.is_empty() {
-                    tracing::debug!(count = permalinks.len(), "parsed GitHub permalinks");
-                    let data = ctx.data.read().await;
-                    if let Some(http_client) = data.get::<HttpClient>() {
-                        for permalink in permalinks {
-                            match permalink.fetch(http_client).await {
-                                Ok(content) => results.push(content),
-                                Err(e) => {
-                                    tracing::error!(error = %e, "failed to expand GitHub permalink")
-                                }
-                            }
-                        }
-                    } else {
-                        tracing::error!("HTTP client not found in TypeMap");
-                    }
-                }
-            }
+            // Expanders are independent of each other, so run them concurrently.
+            // `join_all` preserves registration order in the combined results.
+            let cx = ExpandContext {
+                ctx: &ctx,
+                message: &request,
+                guild_id: request_guild_id,
+            };
+            let results: Vec<ExpandedContent> = join_all(
+                EXPANDERS
+                    .iter()
+                    .filter(|expander| expander.enabled(config))
+                    .map(|expander| expander.expand_all(&cx)),
+            )
+            .await
+            .into_iter()
+            .flatten()
+            .collect();
 
             if results.is_empty() {
                 if let Some(word) = unknown_command {
-                    let command = crate::command::Command::Unknown(word);
-                    tracing::debug!(?command, "handling mention command");
-                    crate::command::execute(&ctx, &request, command).await;
+                    dispatch_command(&ctx, &request, crate::command::Command::Unknown(word)).await;
                 } else {
                     tracing::debug!("no expandable content found");
                 }
@@ -156,6 +98,12 @@ impl EventHandler for BabyriteEventHandler {
         .instrument(span)
         .await;
     }
+}
+
+/// Logs and executes a parsed mention command.
+async fn dispatch_command(ctx: &Context, request: &Message, command: crate::command::Command) {
+    tracing::debug!(?command, "handling mention command");
+    crate::command::execute(ctx, request, command).await;
 }
 
 /// Sends expanded contents as a reply to the original message.

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -6,7 +6,72 @@
 pub mod discord;
 pub mod github;
 
+use crate::config::BabyriteConfig;
+use regex::Regex;
+use serenity::all::{Context, GuildId, Message};
 use serenity_builder::model::embed::SerenityEmbed;
+use std::collections::HashSet;
+
+/// Shared inputs for expanding the links of one message.
+pub struct ExpandContext<'a> {
+    /// The serenity context.
+    pub ctx: &'a Context,
+    /// The message whose links are being expanded.
+    pub message: &'a Message,
+    /// The guild the message was sent in.
+    pub guild_id: GuildId,
+}
+
+/// A link expander: parses its own link type out of a message and expands
+/// each link into [`ExpandedContent`].
+///
+/// Adding a new link type means implementing this trait and registering the
+/// expander in [`EXPANDERS`]; the event handler needs no changes.
+#[serenity::async_trait]
+pub trait LinkExpander: Send + Sync {
+    /// Whether this expander is enabled under `config`.
+    fn enabled(&self, config: &BabyriteConfig) -> bool;
+
+    /// Parses and expands all links of this expander's type in the message.
+    ///
+    /// Failures are logged per link and never abort the other links or
+    /// expanders, so this returns only the successful expansions.
+    async fn expand_all(&self, cx: &ExpandContext<'_>) -> Vec<ExpandedContent>;
+}
+
+/// All registered link expanders, in the order their results appear in a reply.
+pub static EXPANDERS: &[&dyn LinkExpander] = &[&discord::DiscordExpander, &github::GitHubExpander];
+
+/// Maximum number of links expanded per message.
+const MAX_LINKS_PER_MESSAGE: usize = 3;
+
+/// Extracts links matching `regex` from `text`, applying the shared link policy:
+/// URLs wrapped in angle brackets (e.g. `<https://...>`) are skipped, duplicate
+/// URLs are ignored, and at most [`MAX_LINKS_PER_MESSAGE`] links are returned.
+///
+/// `parse` converts a regex match into the expander-specific link type;
+/// returning `None` drops that match.
+pub(crate) fn parse_links<T>(
+    text: &str,
+    regex: &Regex,
+    parse: impl Fn(&regex::Captures) -> Option<T>,
+) -> Vec<T> {
+    let mut seen_urls = HashSet::new();
+    regex
+        .captures_iter(text)
+        .filter_map(|captures| {
+            let m = captures.get(0)?;
+            if m.start() > 0 && text.as_bytes()[m.start() - 1] == b'<' {
+                return None;
+            }
+            if !seen_urls.insert(m.as_str()) {
+                return None;
+            }
+            parse(&captures)
+        })
+        .take(MAX_LINKS_PER_MESSAGE)
+        .collect()
+}
 
 /// Expanded content produced by a link expander.
 ///

--- a/src/expand/discord.rs
+++ b/src/expand/discord.rs
@@ -13,10 +13,11 @@ use serenity::all::{
 use serenity_builder::model::embed::SerenityEmbed;
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
-use url::Url;
 
-use super::{ExpandError, ExpandedContent};
+use super::{ExpandContext, ExpandError, ExpandedContent, LinkExpander};
 use crate::cache::CacheArgs;
+use crate::config::BabyriteConfig;
+use serenity::futures::future::join_all;
 
 /// Regex pattern for matching Discord message links.
 ///
@@ -37,12 +38,80 @@ pub struct MessageLinkIDs {
 }
 
 /// A preview containing the message and its channel.
-#[derive(serde::Deserialize, Debug)]
+#[derive(Debug)]
 pub struct Preview {
     /// The message to preview.
     pub message: Message,
     /// The channel containing the message.
     pub channel: GuildChannel,
+}
+
+/// Discord message link expander.
+pub struct DiscordExpander;
+
+#[serenity::async_trait]
+impl LinkExpander for DiscordExpander {
+    /// Discord link expansion is the bot's core function and has no feature flag.
+    fn enabled(&self, _config: &BabyriteConfig) -> bool {
+        true
+    }
+
+    /// Expands Discord message links into embed previews.
+    ///
+    /// Cross-guild links are skipped. The source channel is resolved once — the
+    /// expanded preview is posted there, so it is needed to verify each link
+    /// target is at least as visible as that channel. If it cannot be resolved,
+    /// Discord expansion is skipped entirely (other expanders are unaffected).
+    async fn expand_all(&self, cx: &ExpandContext<'_>) -> Vec<ExpandedContent> {
+        let links = MessageLinkIDs::parse_all(&cx.message.content);
+        if links.is_empty() {
+            return Vec::new();
+        }
+        tracing::debug!(count = links.len(), "parsed Discord links");
+
+        let links: Vec<_> = links
+            .into_iter()
+            .filter(|ids| {
+                if ids.guild_id != cx.guild_id {
+                    tracing::debug!(
+                        link_guild_id = %ids.guild_id,
+                        "skipping cross-guild Discord link"
+                    );
+                    return false;
+                }
+                true
+            })
+            .collect();
+        if links.is_empty() {
+            return Vec::new();
+        }
+
+        let source_channel = match (CacheArgs {
+            guild_id: cx.guild_id,
+            channel_id: cx.message.channel_id,
+        })
+        .get(cx.ctx)
+        .await
+        {
+            Ok(channel) => channel,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to resolve source channel");
+                return Vec::new();
+            }
+        };
+
+        join_all(links.iter().map(|ids| ids.fetch(cx.ctx, &source_channel)))
+            .await
+            .into_iter()
+            .filter_map(|result| match result {
+                Ok(content) => Some(content),
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to expand Discord link");
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 /// Errors that can occur when generating a Discord message preview.
@@ -67,44 +136,16 @@ impl MessageLinkIDs {
     /// Parses all Discord message links from the given text.
     ///
     /// Returns a `Vec<MessageLinkIDs>` containing all valid message links found.
-    ///
-    /// Note: Duplicate URLs are ignored, and a maximum of 3 links are returned.
+    /// The shared link policy applies (see [`super::parse_links`]): angle-bracket
+    /// wrapped and duplicate URLs are ignored, and at most 3 links are returned.
     pub fn parse_all(text: &str) -> Vec<MessageLinkIDs> {
-        let mut seen_urls = HashSet::new();
-        MESSAGE_LINK_REGEX
-            .captures_iter(text)
-            .filter_map(|captures| {
-                let m = captures.get(0)?;
-                let full_url = m.as_str();
-                // Skip URLs wrapped in angle brackets (e.g., <https://...>)
-                if m.start() > 0 && text.as_bytes()[m.start() - 1] == b'<' {
-                    return None;
-                }
-                if !seen_urls.insert(full_url.to_string()) {
-                    return None;
-                }
-
-                let url = Url::parse(full_url).ok()?;
-
-                if !matches!(
-                    url.domain(),
-                    Some("discord.com") | Some("canary.discord.com") | Some("ptb.discord.com")
-                ) {
-                    return None;
-                }
-
-                let guild_id = GuildId::new(captures.get(1)?.as_str().parse().ok()?);
-                let channel_id = ChannelId::new(captures.get(2)?.as_str().parse().ok()?);
-                let message_id = MessageId::new(captures.get(3)?.as_str().parse().ok()?);
-
-                Some(MessageLinkIDs {
-                    guild_id,
-                    channel_id,
-                    message_id,
-                })
+        super::parse_links(text, &MESSAGE_LINK_REGEX, |captures| {
+            Some(MessageLinkIDs {
+                guild_id: GuildId::new(captures.get(1)?.as_str().parse().ok()?),
+                channel_id: ChannelId::new(captures.get(2)?.as_str().parse().ok()?),
+                message_id: MessageId::new(captures.get(3)?.as_str().parse().ok()?),
             })
-            .take(3) // Limit to maximum 3 links
-            .collect()
+        })
     }
 
     /// Fetches the linked message and returns an embed preview.
@@ -125,13 +166,13 @@ impl MessageLinkIDs {
         ctx: &Context,
         source_channel: &GuildChannel,
     ) -> Result<ExpandedContent, ExpandError> {
-        let preview = Preview::get(self, ctx, source_channel).await?;
-        let (message, channel) = (preview.message, preview.channel);
+        let Preview { message, channel } = Preview::get(self, ctx, source_channel).await?;
 
+        let author_icon_url = message.author.avatar_url().unwrap_or_default();
         let embed = SerenityEmbed::builder()
             .description(message.content)
-            .author_name(message.author.name.clone())
-            .author_icon_url(message.author.avatar_url().unwrap_or_default())
+            .author_name(message.author.name)
+            .author_icon_url(author_icon_url)
             .footer_text(channel.name)
             .timestamp(message.timestamp)
             .color(0x7A4AFFu32)
@@ -199,6 +240,14 @@ fn viewing_roles(
         .copied()
         .unwrap_or_else(Permissions::empty);
 
+    let overwrite_by_role: HashMap<RoleId, (Permissions, Permissions)> = overwrites
+        .iter()
+        .filter_map(|ow| match ow.kind {
+            PermissionOverwriteType::Role(id) => Some((id, (ow.allow, ow.deny))),
+            _ => None,
+        })
+        .collect();
+
     let mut set = HashSet::new();
     for (&role_id, &perms) in role_perms {
         let base = everyone_base | perms;
@@ -209,14 +258,12 @@ fn viewing_roles(
 
         let mut allowed = base.contains(Permissions::VIEW_CHANNEL);
         for target in [everyone_role_id, role_id] {
-            for ow in overwrites {
-                if matches!(ow.kind, PermissionOverwriteType::Role(id) if id == target) {
-                    if ow.deny.contains(Permissions::VIEW_CHANNEL) {
-                        allowed = false;
-                    }
-                    if ow.allow.contains(Permissions::VIEW_CHANNEL) {
-                        allowed = true;
-                    }
+            if let Some(&(allow, deny)) = overwrite_by_role.get(&target) {
+                if deny.contains(Permissions::VIEW_CHANNEL) {
+                    allowed = false;
+                }
+                if allow.contains(Permissions::VIEW_CHANNEL) {
+                    allowed = true;
                 }
             }
         }
@@ -249,6 +296,79 @@ async fn permission_channel(
     .get(ctx)
     .await
     .map_err(|_| PreviewError::Cache)
+}
+
+/// Validates that everyone who can view `source_channel` could also view `channel`.
+///
+/// The expanded content is posted as a single message that all members of
+/// `source_channel` can read, so the linked channel must be at least as visible
+/// as the source channel to avoid leaking restricted content.
+async fn check_visibility(
+    channel: &GuildChannel,
+    source_channel: &GuildChannel,
+    guild_id: GuildId,
+    ctx: &Context,
+) -> Result<(), PreviewError> {
+    // Private threads cannot be represented by the role-set comparison
+    // (membership is per-user), and DMs are outside the guild context, so
+    // both are rejected. Public/news threads fall through and are judged via
+    // their parent channel.
+    if matches!(
+        channel.kind,
+        ChannelType::PrivateThread | ChannelType::Private
+    ) {
+        tracing::debug!(kind = ?channel.kind, "rejected: private channel or thread");
+        return Err(PreviewError::Permission);
+    }
+
+    // Threads follow their parent channel's permissions, so resolve both the
+    // link target and the request source to the channel that actually
+    // defines visibility before comparing.
+    let (dest_perm, source_perm) = tokio::try_join!(
+        permission_channel(channel, ctx),
+        permission_channel(source_channel, ctx),
+    )?;
+
+    // A per-member deny on the target cannot be represented in the role-set
+    // comparison below, so reject conservatively.
+    if has_member_view_deny(&dest_perm.permission_overwrites) {
+        tracing::debug!("rejected: target has a per-member VIEW_CHANNEL deny");
+        return Err(PreviewError::Permission);
+    }
+
+    let everyone_role_id = RoleId::new(guild_id.get());
+    // Clone the role permission map out of the cache so the non-`Send`
+    // `GuildRef` is dropped immediately — holding it across an `await` would
+    // make the future `!Send` and fail to compile in the event handler.
+    let role_perms: HashMap<RoleId, Permissions> = {
+        let guild = ctx.cache.guild(guild_id).ok_or(PreviewError::Permission)?;
+        guild
+            .roles
+            .iter()
+            .map(|(&id, role)| (id, role.permissions))
+            .collect()
+    };
+
+    let dest_roles = viewing_roles(
+        &dest_perm.permission_overwrites,
+        &role_perms,
+        everyone_role_id,
+    );
+    let source_roles = viewing_roles(
+        &source_perm.permission_overwrites,
+        &role_perms,
+        everyone_role_id,
+    );
+    if !source_roles.is_subset(&dest_roles) {
+        tracing::debug!(
+            source_roles = source_roles.len(),
+            dest_roles = dest_roles.len(),
+            "rejected: source channel is more visible than the target"
+        );
+        return Err(PreviewError::Permission);
+    }
+
+    Ok(())
 }
 
 impl Preview {
@@ -294,69 +414,11 @@ impl Preview {
         // When the link points to the same channel the request came from, the
         // expansion is posted back into that very channel. Every member who can
         // read the reply can already read the original message, so there is
-        // nothing to leak and all visibility checks below can be skipped. This
+        // nothing to leak and the visibility checks can be skipped. This
         // notably covers quoting within a private channel, which would otherwise
         // be rejected by the per-member deny guard.
         if requires_visibility_check(args.channel_id, source_channel.id) {
-            // Private threads cannot be represented by the role-set comparison
-            // (membership is per-user), and DMs are outside the guild context, so
-            // both are rejected. Public/news threads fall through and are judged via
-            // their parent channel.
-            if matches!(
-                channel.kind,
-                ChannelType::PrivateThread | ChannelType::Private
-            ) {
-                tracing::debug!(kind = ?channel.kind, "rejected: private channel or thread");
-                return Err(PreviewError::Permission);
-            }
-
-            // Threads follow their parent channel's permissions, so resolve both the
-            // link target and the request source to the channel that actually
-            // defines visibility before comparing.
-            let dest_perm = permission_channel(&channel, ctx).await?;
-            let source_perm = permission_channel(source_channel, ctx).await?;
-
-            // A per-member deny on the target cannot be represented in the role-set
-            // comparison below, so reject conservatively.
-            if has_member_view_deny(&dest_perm.permission_overwrites) {
-                tracing::debug!("rejected: target has a per-member VIEW_CHANNEL deny");
-                return Err(PreviewError::Permission);
-            }
-
-            let everyone_role_id = RoleId::new(args.guild_id.get());
-            // Clone the role permission map out of the cache so the `GuildRef` is
-            // dropped before the `await` below (holding it across `await` would make
-            // the future `!Send` and fail to compile in the event handler).
-            let role_perms: HashMap<RoleId, Permissions> = {
-                let guild = ctx
-                    .cache
-                    .guild(args.guild_id)
-                    .ok_or(PreviewError::Permission)?;
-                guild
-                    .roles
-                    .iter()
-                    .map(|(&id, role)| (id, role.permissions))
-                    .collect()
-            };
-
-            let dest_roles = viewing_roles(
-                &dest_perm.permission_overwrites,
-                &role_perms,
-                everyone_role_id,
-            );
-            let source_roles = viewing_roles(
-                &source_perm.permission_overwrites,
-                &role_perms,
-                everyone_role_id,
-            );
-            if !source_roles.is_subset(&dest_roles) {
-                tracing::debug!(
-                    source_roles = source_roles.len(),
-                    dest_roles = dest_roles.len(),
-                    "rejected: source channel is more visible than the target"
-                );
-                return Err(PreviewError::Permission);
-            }
+            check_visibility(&channel, source_channel, args.guild_id, ctx).await?;
         }
 
         let started = std::time::Instant::now();

--- a/src/expand/github.rs
+++ b/src/expand/github.rs
@@ -4,12 +4,20 @@
 //! and fetching raw file content to display as code blocks.
 
 use regex::Regex;
-use std::collections::HashSet;
+use serenity::futures::future::join_all;
+use serenity::prelude::TypeMapKey;
 use std::sync::LazyLock;
 
-use super::{ExpandError, ExpandedContent};
+use super::{ExpandContext, ExpandError, ExpandedContent, LinkExpander};
 use crate::config::BabyriteConfig;
-use crate::utils::language_from_extension;
+use crate::utils::language_for_path;
+
+/// TypeMap key for the shared reqwest HTTP client used to fetch raw content.
+pub struct HttpClient;
+
+impl TypeMapKey for HttpClient {
+    type Value = reqwest::Client;
+}
 
 /// Regex pattern for matching GitHub blob URLs.
 ///
@@ -56,6 +64,48 @@ pub struct LineRange {
     pub end: usize,
 }
 
+/// GitHub permalink expander.
+pub struct GitHubExpander;
+
+#[serenity::async_trait]
+impl LinkExpander for GitHubExpander {
+    fn enabled(&self, config: &BabyriteConfig) -> bool {
+        config.features.github_permalink
+    }
+
+    /// Expands GitHub permalinks into code blocks.
+    async fn expand_all(&self, cx: &ExpandContext<'_>) -> Vec<ExpandedContent> {
+        let permalinks = GitHubPermalink::parse_all(&cx.message.content);
+        if permalinks.is_empty() {
+            return Vec::new();
+        }
+        tracing::debug!(count = permalinks.len(), "parsed GitHub permalinks");
+
+        // `reqwest::Client` is internally reference-counted, so clone it out of
+        // the TypeMap instead of holding the read guard across the fetches below.
+        let http_client = {
+            let data = cx.ctx.data.read().await;
+            data.get::<HttpClient>().cloned()
+        };
+        let Some(http_client) = http_client else {
+            tracing::error!("HTTP client not found in TypeMap");
+            return Vec::new();
+        };
+
+        join_all(permalinks.iter().map(|p| p.fetch(&http_client)))
+            .await
+            .into_iter()
+            .filter_map(|result| match result {
+                Ok(content) => Some(content),
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to expand GitHub permalink");
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
 /// Errors that can occur when expanding a GitHub permalink.
 #[derive(thiserror::Error, Debug)]
 pub enum GitHubExpandError {
@@ -74,51 +124,31 @@ impl GitHubPermalink {
     /// Parses all GitHub permalink URLs from the given text.
     ///
     /// Matches URLs with commit SHAs, branch names, or tag names.
-    ///
-    /// Note: Duplicate URLs are ignored, and a maximum of 3 links are returned.
+    /// The shared link policy applies (see [`super::parse_links`]): angle-bracket
+    /// wrapped and duplicate URLs are ignored, and at most 3 links are returned.
     pub fn parse_all(text: &str) -> Vec<GitHubPermalink> {
-        let mut seen_urls = HashSet::new();
-        GITHUB_PERMALINK_REGEX
-            .captures_iter(text)
-            .filter_map(|captures| {
-                let m = captures.get(0)?;
-                let full_url = m.as_str();
-                // Skip URLs wrapped in angle brackets (e.g., <https://...>)
-                if m.start() > 0 && text.as_bytes()[m.start() - 1] == b'<' {
-                    return None;
+        super::parse_links(text, &GITHUB_PERMALINK_REGEX, |captures| {
+            let line_range = match captures.get(5) {
+                Some(start) => {
+                    let start = start.as_str().parse().ok()?;
+                    // A missing end (e.g. `#L42`) means a single-line reference.
+                    let end = match captures.get(6) {
+                        Some(end) => end.as_str().parse().ok()?,
+                        None => start,
+                    };
+                    Some(LineRange { start, end })
                 }
-                if !seen_urls.insert(full_url.to_string()) {
-                    return None;
-                }
+                None => None,
+            };
 
-                let owner = captures.get(1)?.as_str().to_string();
-                let repo = captures.get(2)?.as_str().to_string();
-                let git_ref = captures.get(3)?.as_str().to_string();
-                let path = captures.get(4)?.as_str().to_string();
-
-                let line_range = match (captures.get(5), captures.get(6)) {
-                    (Some(start), Some(end)) => {
-                        let s = start.as_str().parse().ok()?;
-                        let e = end.as_str().parse().ok()?;
-                        Some(LineRange { start: s, end: e })
-                    }
-                    (Some(start), None) => {
-                        let s = start.as_str().parse().ok()?;
-                        Some(LineRange { start: s, end: s })
-                    }
-                    _ => None,
-                };
-
-                Some(GitHubPermalink {
-                    owner,
-                    repo,
-                    git_ref,
-                    path,
-                    line_range,
-                })
+            Some(GitHubPermalink {
+                owner: captures.get(1)?.as_str().to_string(),
+                repo: captures.get(2)?.as_str().to_string(),
+                git_ref: captures.get(3)?.as_str().to_string(),
+                path: captures.get(4)?.as_str().to_string(),
+                line_range,
             })
-            .take(3) // Limit to maximum 3 links
-            .collect()
+        })
     }
 
     /// Fetches the raw file content from GitHub and returns a code block.
@@ -190,9 +220,9 @@ impl GitHubPermalink {
             Some(range) => {
                 let start = range.start.saturating_sub(1); // 0-indexed
                 let end = range.end.min(all_lines.len());
-                let selected: Vec<&str> = all_lines.get(start..end).unwrap_or_default().to_vec();
+                let selected = all_lines.get(start..end).unwrap_or_default();
 
-                let (code, truncated) = truncate_lines(&selected, max_lines);
+                let (code, truncated) = truncate_lines(selected, max_lines);
                 let info = if truncated {
                     format!(
                         "L{}-L{}, truncated to {} lines",
@@ -217,17 +247,15 @@ impl GitHubPermalink {
         let display_ref = shorten_ref(&self.git_ref);
         let language = language_for_path(&self.path);
 
-        let metadata = if line_info.is_empty() {
-            format!(
-                "`{}` - {}/{}@{}",
-                self.path, self.owner, self.repo, display_ref
-            )
+        let line_part = if line_info.is_empty() {
+            String::new()
         } else {
-            format!(
-                "`{}` ({}) - {}/{}@{}",
-                self.path, line_info, self.owner, self.repo, display_ref
-            )
+            format!(" ({line_info})")
         };
+        let metadata = format!(
+            "`{}`{} - {}/{}@{}",
+            self.path, line_part, self.owner, self.repo, display_ref
+        );
 
         ExpandedContent::CodeBlock {
             language: language.to_string(),
@@ -252,23 +280,10 @@ fn shorten_ref(git_ref: &str) -> &str {
     }
 }
 
-/// Extracts the filename from a path and returns the appropriate language identifier.
-fn language_for_path(path: &str) -> &str {
-    let filename = path.rsplit('/').next().unwrap_or(path);
-    match filename.rsplit_once('.') {
-        Some((_, ext)) => language_from_extension(ext),
-        None => language_from_extension(filename),
-    }
-}
-
 /// Truncates lines to the given maximum, returning the joined string and whether truncation occurred.
 fn truncate_lines(lines: &[&str], max: usize) -> (String, bool) {
-    if lines.len() > max {
-        let truncated: Vec<&str> = lines[..max].to_vec();
-        (truncated.join("\n"), true)
-    } else {
-        (lines.join("\n"), false)
-    }
+    let kept = &lines[..lines.len().min(max)];
+    (kept.join("\n"), lines.len() > max)
 }
 
 #[cfg(test)]
@@ -535,38 +550,6 @@ mod tests {
         let results = GitHubPermalink::parse_all(text);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].git_ref, "abcd");
-    }
-
-    // --- language_for_path ---
-
-    #[test]
-    fn language_for_path_basic_extension() {
-        assert_eq!(language_for_path("src/main.rs"), "rust");
-    }
-
-    #[test]
-    fn language_for_path_dockerfile_in_subdir() {
-        assert_eq!(language_for_path("docker/Dockerfile"), "dockerfile");
-    }
-
-    #[test]
-    fn language_for_path_dotted_directory() {
-        assert_eq!(language_for_path("some.config/Dockerfile"), "dockerfile");
-    }
-
-    #[test]
-    fn language_for_path_makefile_in_subdir() {
-        assert_eq!(language_for_path("build/Makefile"), "makefile");
-    }
-
-    #[test]
-    fn language_for_path_multiple_dots() {
-        assert_eq!(language_for_path("file.test.ts"), "typescript");
-    }
-
-    #[test]
-    fn language_for_path_dotfile() {
-        assert_eq!(language_for_path(".gitignore"), "gitignore");
     }
 
     // --- build_code_block ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,8 @@ mod utils;
 use crate::{
     command::ShardManagerContainer,
     config::{BabyriteConfig, EnvConfig, LogFormat},
-    event::{BabyriteEventHandler, HttpClient},
+    event::BabyriteEventHandler,
+    expand::github::HttpClient,
 };
 use serenity::all::GatewayIntents;
 use tracing_subscriber::EnvFilter;
@@ -57,9 +58,7 @@ async fn main() -> anyhow::Result<()> {
         data.insert::<ShardManagerContainer>(client.shard_manager.clone());
     }
 
-    if let Err(why) = client.start().await {
-        return Err(anyhow::anyhow!(why));
-    }
+    client.start().await?;
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,10 +15,8 @@ pub fn language_from_extension(extension: &str) -> &str {
         "go" => "go",
         "java" => "java",
         "kt" | "kts" => "kotlin",
-        "c" => "c",
-        "h" => "c",
-        "cpp" | "cc" | "cxx" => "cpp",
-        "hpp" | "hxx" => "cpp",
+        "c" | "h" => "c",
+        "cpp" | "cc" | "cxx" | "hpp" | "hxx" => "cpp",
         "cs" => "csharp",
         "swift" => "swift",
         "php" => "php",
@@ -54,6 +52,18 @@ pub fn language_from_extension(extension: &str) -> &str {
         "proto" => "protobuf",
         "makefile" | "mk" => "makefile",
         _ => extension,
+    }
+}
+
+/// Returns the language identifier for syntax highlighting based on a file path.
+///
+/// Uses the file extension when present; extensionless filenames
+/// (e.g. `Dockerfile`, `Makefile`) are looked up by name.
+pub fn language_for_path(path: &str) -> &str {
+    let filename = path.rsplit('/').next().unwrap_or(path);
+    match filename.rsplit_once('.') {
+        Some((_, ext)) => language_from_extension(ext),
+        None => language_from_extension(filename),
     }
 }
 
@@ -117,5 +127,35 @@ mod tests {
         assert_eq!(language_from_extension("dockerfile"), "dockerfile");
         assert_eq!(language_from_extension("Makefile"), "makefile");
         assert_eq!(language_from_extension("makefile"), "makefile");
+    }
+
+    #[test]
+    fn language_for_path_basic_extension() {
+        assert_eq!(language_for_path("src/main.rs"), "rust");
+    }
+
+    #[test]
+    fn language_for_path_dockerfile_in_subdir() {
+        assert_eq!(language_for_path("docker/Dockerfile"), "dockerfile");
+    }
+
+    #[test]
+    fn language_for_path_dotted_directory() {
+        assert_eq!(language_for_path("some.config/Dockerfile"), "dockerfile");
+    }
+
+    #[test]
+    fn language_for_path_makefile_in_subdir() {
+        assert_eq!(language_for_path("build/Makefile"), "makefile");
+    }
+
+    #[test]
+    fn language_for_path_multiple_dots() {
+        assert_eq!(language_for_path("file.test.ts"), "typescript");
+    }
+
+    #[test]
+    fn language_for_path_dotfile() {
+        assert_eq!(language_for_path(".gitignore"), "gitignore");
     }
 }


### PR DESCRIPTION
## Why

The Discord and GitHub link expanders had grown into two parallel copies of the same scaffolding — identical link-parsing skeletons, identical moka cache builder config, and a hand-written expansion pipeline per link type inlined in the event handler. A third link type would have meant a third copy of all of it. This is a behavior-preserving cleanup that consolidates the shared structure and removes duplicated/wasted work the review surfaced.

## What

**Generalization**
- Add a `LinkExpander` trait + `EXPANDERS` registry (`src/expand.rs`). The event handler now runs every enabled expander concurrently and flattens the results; a new link type is an `impl` plus one registry entry. The per-expander feature flag asymmetry (GitHub had one, Discord didn't) is absorbed into `enabled()`.
- Move the per-message link policy (skip `<...>`-wrapped, dedup, cap at 3) into a single `parse_links` helper; both `parse_all`s pass only their capture→struct closure.
- Build both channel caches from one `channel_cache` helper instead of two copies of the builder chain.
- Extract `check_visibility` from `Preview::get` so the visibility flow reads top to bottom.
- Lift `language_for_path` next to its extension table in `utils.rs`.

**Removed duplication / wasted work**
- Drop the `Url::parse` domain re-validation (the regex already anchors the host) and the now-unused `url` dependency.
- Fetch the channel list with one `GuildId::channels` call instead of `get_guild` + `channels`.
- Run independent link fetches (`join_all`) and the dest/source permission lookups (`try_join!`) concurrently.
- Index channel overwrites into a map so `viewing_roles` is O(R+O) instead of O(R×O).
- Collapse config field-level default fns onto container-level `#[serde(default)]` + `Default` impls; fix the `init()` set-failure being mislabeled `Parse` instead of `Set`.
- Deduplicate the `ping` reply formatting (`render_pong`), the command-dispatch pair (`dispatch_command`), and the `empty_string_as_none` test struct.

## Testing

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features`, and `cargo test` all pass (102 tests). Behavior is unchanged.

## Follow-ups

Deeper changes surfaced during review were filed separately rather than bundled here: #624, #625, #626, #627, #628, #629.

---
Generated by Claude Code
