### PR TITLE
ci: run coverage on nightly to exclude untestable runtime glue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # Coverage runs on nightly so that `#[cfg_attr(coverage_nightly,
+      # coverage(off))]` takes effect — the `coverage_nightly` cfg is only set by
+      # cargo-llvm-cov under nightly. This excludes untestable runtime glue (live
+      # Serenity gateway / HTTP) from the reported numbers. `rust-toolchain.toml`
+      # pins stable, so the `cargo +nightly` below is required to override it.
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
 
       - name: Setup cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -52,7 +59,7 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
+        run: cargo +nightly llvm-cov --all-features --workspace --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/src/expand/discord.rs
+++ b/src/expand/discord.rs
@@ -62,6 +62,7 @@ impl LinkExpander for DiscordExpander {
     /// expanded preview is posted there, so it is needed to verify each link
     /// target is at least as visible as that channel. If it cannot be resolved,
     /// Discord expansion is skipped entirely (other expanders are unaffected).
+    #[cfg_attr(coverage_nightly, coverage(off))]
     async fn expand_all(&self, cx: &ExpandContext<'_>) -> Vec<ExpandedContent> {
         let links = MessageLinkIDs::parse_all(&cx.message.content);
         if links.is_empty() {
@@ -153,6 +154,7 @@ impl MessageLinkIDs {
     /// `source_channel` is the channel where the request originated. It is used to
     /// ensure the linked content is not exposed to members who could not otherwise
     /// view it (see [`Preview::get`]).
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[tracing::instrument(
         skip(self, ctx, source_channel),
         fields(
@@ -280,6 +282,7 @@ fn viewing_roles(
 /// Threads inherit visibility from their parent channel, so for any thread the
 /// parent channel is fetched and returned. Non-thread channels are returned
 /// unchanged. A thread without a `parent_id` is treated as an error.
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn permission_channel(
     channel: &GuildChannel,
     ctx: &Context,
@@ -303,6 +306,7 @@ async fn permission_channel(
 /// The expanded content is posted as a single message that all members of
 /// `source_channel` can read, so the linked channel must be at least as visible
 /// as the source channel to avoid leaking restricted content.
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn check_visibility(
     channel: &GuildChannel,
     source_channel: &GuildChannel,
@@ -385,6 +389,7 @@ impl Preview {
     /// When the link target is the same channel as `source_channel`, the
     /// visibility checks are skipped entirely: the reply lands in that same
     /// channel, so it cannot expose anything its readers cannot already see.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[tracing::instrument(
         skip(args, ctx, source_channel),
         fields(

--- a/src/expand/github.rs
+++ b/src/expand/github.rs
@@ -74,6 +74,7 @@ impl LinkExpander for GitHubExpander {
     }
 
     /// Expands GitHub permalinks into code blocks.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     async fn expand_all(&self, cx: &ExpandContext<'_>) -> Vec<ExpandedContent> {
         let permalinks = GitHubPermalink::parse_all(&cx.message.content);
         if permalinks.is_empty() {


### PR DESCRIPTION
Closes #631. Supersedes #632 (auto-closed when its stacked base branch `refactor/simplify-expanders` was deleted on #630's merge; recreated here against `main`).

## Why

#630 moved the per-link-type expansion pipelines out of `src/event.rs` — already `ignore`d in `codecov.yml` as untestable runtime glue — into `src/expand/discord.rs` / `src/expand/github.rs`, which are not ignored and also hold heavily-tested pure logic. The relocated glue (needs a live Serenity gateway / HTTP client; can't be unit-tested under this project's no-integration-tests, no-mocking convention) dragged reported coverage down (`codecov/project` −4.80%) with no actual loss of testable-logic coverage.

## What

- Annotate the relocated glue functions with the project's existing `#[cfg_attr(coverage_nightly, coverage(off))]` convention: `DiscordExpander::expand_all`, `MessageLinkIDs::fetch`, `permission_channel`, `check_visibility`, `Preview::get` (discord.rs) and `GitHubExpander::expand_all` (github.rs).
- Move the `coverage` CI job to nightly (`dtolnay/rust-toolchain@nightly` + `llvm-tools-preview`, `cargo +nightly llvm-cov`). The `coverage_nightly` cfg is only set by cargo-llvm-cov under nightly, and `rust-toolchain.toml` pins stable, so `+nightly` is required to override it.
- File-level ignore was rejected: excluding whole files would discard the signal for the tested `parse_all` / `viewing_roles` / `build_code_block` logic those files still hold.

## Effect

Locally, `cargo +nightly llvm-cov --all-features --workspace` lifts `expand/discord.rs` from 70.25% to 98.28% line coverage with the glue excluded; pure logic stays counted. This also activates the previously-inert annotations already present on `command.rs` / `github.rs` (`execute_ping`, `fetch`, …) that were dead under the stable toolchain. On PR #632 (same commit) the CI `coverage` job and both `codecov/patch` and `codecov/project` checks went green.

## Note for reviewers

Because the measurement toolchain changes (stable → nightly), the first coverage run shows a one-time discontinuity vs the stable-measured base — expected, and it self-corrects once `main` runs coverage on nightly after merge. Stable `fmt` / `clippy` / `test` are unaffected: the `cfg_attr` expands to nothing off nightly.

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features`, `cargo test` (102 tests) pass on stable.
- `cargo +nightly llvm-cov --all-features --workspace --codecov --output-path codecov.json` (the exact CI command) runs and emits a valid report locally, and passed on CI in #632.

---
Generated with Claude Code
