### PR TITLE
fix(event): stop code blocks from parsing mentions or escaping their fence

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -5,7 +5,9 @@
 
 use crate::config::BabyriteConfig;
 use crate::expand::{EXPANDERS, ExpandContext, ExpandedContent};
-use serenity::all::{ActivityData, Context, EventHandler, Message, Ready};
+use serenity::all::{
+    ActivityData, Context, CreateAllowedMentions, CreateMessage, EventHandler, Message, Ready,
+};
 use serenity::futures::future::join_all;
 use serenity_builder::model::message::{SerenityMessage, SerenityMessageMentionType};
 use tracing::Instrument;
@@ -88,6 +90,7 @@ async fn send_expanded_contents(ctx: &Context, request: &Message, results: Vec<E
                 code,
                 metadata,
             } => {
+                let code = crate::utils::defuse_code_fences(&code);
                 code_blocks.push(format!("{metadata}\n```{language}\n{code}\n```"));
             }
         }
@@ -121,9 +124,18 @@ async fn send_expanded_contents(ctx: &Context, request: &Message, results: Vec<E
         }
     }
 
-    // Send code blocks as plain messages
+    // Send code blocks as plain messages.
+    //
+    // Not `say`: it leaves `allowed_mentions` unset, which makes Discord parse
+    // every mention in the content under the bot's permissions. The content is
+    // fetched from a repository the requester chose, so that would let it borrow
+    // mention rights the requester may not hold. The embed path already sends an
+    // explicit `allowed_mentions`.
     for block in code_blocks {
-        if let Err(e) = request.channel_id.say(&ctx.http, &block).await {
+        let message = CreateMessage::new()
+            .content(&block)
+            .allowed_mentions(CreateAllowedMentions::new());
+        if let Err(e) = request.channel_id.send_message(&ctx.http, message).await {
             tracing::error!(error = ?e, "failed to send code block");
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -67,6 +67,32 @@ pub fn language_for_path(path: &str) -> &str {
     }
 }
 
+/// Rewrites `text` so it cannot terminate a Discord code fence.
+///
+/// Discord closes a code block at the first ``` it encounters, so fetched file
+/// content containing one would escape the fence and have the remainder
+/// rendered as markdown. Runs of backticks are kept below three by wedging in a
+/// zero-width space, which leaves the text visually unchanged. Single and double
+/// backticks are untouched, so ordinary code (template literals, shell quoting)
+/// still displays as written.
+pub fn defuse_code_fences(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut backticks = 0;
+    for c in text.chars() {
+        if c == '`' {
+            if backticks == 2 {
+                out.push('\u{200b}');
+                backticks = 0;
+            }
+            backticks += 1;
+        } else {
+            backticks = 0;
+        }
+        out.push(c);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -157,5 +183,48 @@ mod tests {
     #[test]
     fn language_for_path_dotfile() {
         assert_eq!(language_for_path(".gitignore"), "gitignore");
+    }
+
+    /// The number of consecutive backticks a run of `n` is reduced to.
+    fn longest_backtick_run(text: &str) -> usize {
+        text.chars()
+            .fold((0, 0), |(longest, run), c| {
+                let run = if c == '`' { run + 1 } else { 0 };
+                (longest.max(run), run)
+            })
+            .0
+    }
+
+    #[test]
+    fn code_without_backticks_is_unchanged() {
+        assert_eq!(defuse_code_fences("fn main() {}"), "fn main() {}");
+    }
+
+    #[test]
+    fn short_backtick_runs_are_preserved() {
+        // Inline code and shell quoting must survive verbatim.
+        assert_eq!(defuse_code_fences("let s = `a`;"), "let s = `a`;");
+        assert_eq!(defuse_code_fences("``double``"), "``double``");
+    }
+
+    #[test]
+    fn no_backtick_run_survives_at_fence_length() {
+        // Any run of three or more would close the fence Discord opened.
+        for run in 3..=8 {
+            let input = "`".repeat(run);
+            assert!(
+                longest_backtick_run(&defuse_code_fences(&input)) < 3,
+                "a run of {run} backticks was not defused"
+            );
+        }
+    }
+
+    #[test]
+    fn defusing_keeps_surrounding_text() {
+        let defused = defuse_code_fences("before```after");
+        assert!(longest_backtick_run(&defused) < 3);
+        assert!(defused.starts_with("before"));
+        assert!(defused.ends_with("after"));
+        assert_eq!(defused.matches('`').count(), 3);
     }
 }


### PR DESCRIPTION
Found while reviewing the input/output paths after #642 / #644.

## Why

Two problems on the GitHub code-block send path, which is enabled by default (`features.github_permalink`).

**Mentions were parsed.** Code blocks went out via `ChannelId::say`, which builds `CreateMessage::new().content(content)` and never sets `allowed_mentions`. With the field absent Discord applies its default and parses every mention in the content, under the **message author's** permissions — that is, the bot's. The content is a file from a repository the requester chose, so a file containing `@everyone` let that file borrow mention rights the requester may not hold. The embed path is unaffected: `serenity-builder` sets `allowed_mentions` there, so this was the only unprotected send.

**The fence could be escaped.** `format!("{metadata}\n```{language}\n{code}\n```")` interpolated the fetched file content unescaped, and Discord closes a code block at the first ``` it encounters. A file whose content includes one ended the fence early and had everything after it rendered as markdown in a message attributed to the bot. The 50-line cap and `#L` range do not help — the payload just goes on the first line.

## What changed

- `send_message` with `CreateAllowedMentions::new()` instead of `say`. `parse`/`users`/`roles` are serialized unconditionally by serenity, so an empty builder sends `{"parse":[],"users":[],"roles":[]}` and nothing is parsed.
- New `utils::defuse_code_fences`, applied to `code` before it enters the fence. It keeps backtick runs below three by inserting a zero-width space, so the text stays visually identical while losing the ability to close the fence.

`defuse_code_fences` walks the string rather than using `str::replace("```", ...)`, because non-overlapping replacement leaves new runs behind: five backticks become `` `​`​` `` + `` `` `` — three consecutive backticks again. The property test covers runs of 3 through 8.

Single and double backticks are deliberately untouched so ordinary code (JS template literals, shell quoting, Go raw strings) still renders as written.

## Scope note

Setting `default_allowed_mentions` once on the `Http` in `main.rs` would cover every future send site too. I kept the change local because the embed path already sets its own value and a global default would be an invisible dependency for anything added later — worth doing as a follow-up if more send paths appear.

Residual, not addressed: `metadata` interpolates `owner`/`repo`/`git_ref` outside backticks, and the `[^/]+` capture permits a backtick in an exotic branch name. With mentions disabled the worst case is cosmetic markdown mangling, and the values must name a real GitHub ref for the fetch to succeed at all.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test` — 86 passed (4 new, all on the pure helper)

---
Generated by Claude Code